### PR TITLE
Allow same version upgrades

### DIFF
--- a/res/windows/wix/space-acres.wxs
+++ b/res/windows/wix/space-acres.wxs
@@ -80,7 +80,8 @@
 
         <MajorUpgrade
             Schedule='afterInstallInitialize'
-            DowngradeErrorMessage='A newer version of [ProductName] is already installed. Setup will now exit.'/>
+            DowngradeErrorMessage='A newer version of [ProductName] is already installed. Setup will now exit.'
+            AllowSameVersionUpgrades='yes'/>
 
         <Media Id='1' Cabinet='media1.cab' EmbedCab='yes' DiskPrompt='CD-ROM #1'/>
         <Property Id='DiskPrompt' Value='Space Acres Installation'/>


### PR DESCRIPTION
This should fix the problem of getting Space Acres installed twice if two builds are installed, but have the same version. Now second installation should replace the first one (as user would expect).