### PR TITLE
Update to upcoming Subspace release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1973,7 +1973,7 @@ checksum = "7059fff8937831a9ae6f0fe4d658ffabf58f2ca96aa9dec1c889f936f705f216"
 [[package]]
 name = "cross-domain-message-gossip"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=1fd384b489e816679a95333b3ff3d9a2d2d8b0a1#1fd384b489e816679a95333b3ff3d9a2d2d8b0a1"
+source = "git+https://github.com/subspace/subspace?rev=3bfff27aaa4246706c5f5156871f0241830ee123#3bfff27aaa4246706c5f5156871f0241830ee123"
 dependencies = [
  "futures",
  "parity-scale-codec",
@@ -2460,7 +2460,7 @@ dependencies = [
 [[package]]
 name = "domain-block-preprocessor"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=1fd384b489e816679a95333b3ff3d9a2d2d8b0a1#1fd384b489e816679a95333b3ff3d9a2d2d8b0a1"
+source = "git+https://github.com/subspace/subspace?rev=3bfff27aaa4246706c5f5156871f0241830ee123#3bfff27aaa4246706c5f5156871f0241830ee123"
 dependencies = [
  "async-trait",
  "domain-runtime-primitives",
@@ -2488,7 +2488,7 @@ dependencies = [
 [[package]]
 name = "domain-runtime-primitives"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=1fd384b489e816679a95333b3ff3d9a2d2d8b0a1#1fd384b489e816679a95333b3ff3d9a2d2d8b0a1"
+source = "git+https://github.com/subspace/subspace?rev=3bfff27aaa4246706c5f5156871f0241830ee123#3bfff27aaa4246706c5f5156871f0241830ee123"
 dependencies = [
  "fp-account",
  "frame-support",
@@ -6618,7 +6618,7 @@ dependencies = [
 [[package]]
 name = "orml-vesting"
 version = "0.4.1-dev"
-source = "git+https://github.com/subspace/subspace?rev=1fd384b489e816679a95333b3ff3d9a2d2d8b0a1#1fd384b489e816679a95333b3ff3d9a2d2d8b0a1"
+source = "git+https://github.com/subspace/subspace?rev=3bfff27aaa4246706c5f5156871f0241830ee123#3bfff27aaa4246706c5f5156871f0241830ee123"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6670,7 +6670,7 @@ dependencies = [
 [[package]]
 name = "pallet-domains"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=1fd384b489e816679a95333b3ff3d9a2d2d8b0a1#1fd384b489e816679a95333b3ff3d9a2d2d8b0a1"
+source = "git+https://github.com/subspace/subspace?rev=3bfff27aaa4246706c5f5156871f0241830ee123#3bfff27aaa4246706c5f5156871f0241830ee123"
 dependencies = [
  "domain-runtime-primitives",
  "frame-benchmarking",
@@ -6696,7 +6696,7 @@ dependencies = [
 [[package]]
 name = "pallet-messenger"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=1fd384b489e816679a95333b3ff3d9a2d2d8b0a1#1fd384b489e816679a95333b3ff3d9a2d2d8b0a1"
+source = "git+https://github.com/subspace/subspace?rev=3bfff27aaa4246706c5f5156871f0241830ee123#3bfff27aaa4246706c5f5156871f0241830ee123"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6734,7 +6734,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences-subspace"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=1fd384b489e816679a95333b3ff3d9a2d2d8b0a1#1fd384b489e816679a95333b3ff3d9a2d2d8b0a1"
+source = "git+https://github.com/subspace/subspace?rev=3bfff27aaa4246706c5f5156871f0241830ee123#3bfff27aaa4246706c5f5156871f0241830ee123"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6748,7 +6748,7 @@ dependencies = [
 [[package]]
 name = "pallet-rewards"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=1fd384b489e816679a95333b3ff3d9a2d2d8b0a1#1fd384b489e816679a95333b3ff3d9a2d2d8b0a1"
+source = "git+https://github.com/subspace/subspace?rev=3bfff27aaa4246706c5f5156871f0241830ee123#3bfff27aaa4246706c5f5156871f0241830ee123"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6760,7 +6760,7 @@ dependencies = [
 [[package]]
 name = "pallet-runtime-configs"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=1fd384b489e816679a95333b3ff3d9a2d2d8b0a1#1fd384b489e816679a95333b3ff3d9a2d2d8b0a1"
+source = "git+https://github.com/subspace/subspace?rev=3bfff27aaa4246706c5f5156871f0241830ee123#3bfff27aaa4246706c5f5156871f0241830ee123"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6774,7 +6774,7 @@ dependencies = [
 [[package]]
 name = "pallet-subspace"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=1fd384b489e816679a95333b3ff3d9a2d2d8b0a1#1fd384b489e816679a95333b3ff3d9a2d2d8b0a1"
+source = "git+https://github.com/subspace/subspace?rev=3bfff27aaa4246706c5f5156871f0241830ee123#3bfff27aaa4246706c5f5156871f0241830ee123"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6797,7 +6797,7 @@ dependencies = [
 [[package]]
 name = "pallet-subspace-mmr"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=1fd384b489e816679a95333b3ff3d9a2d2d8b0a1#1fd384b489e816679a95333b3ff3d9a2d2d8b0a1"
+source = "git+https://github.com/subspace/subspace?rev=3bfff27aaa4246706c5f5156871f0241830ee123#3bfff27aaa4246706c5f5156871f0241830ee123"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6849,7 +6849,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-fees"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=1fd384b489e816679a95333b3ff3d9a2d2d8b0a1#1fd384b489e816679a95333b3ff3d9a2d2d8b0a1"
+source = "git+https://github.com/subspace/subspace?rev=3bfff27aaa4246706c5f5156871f0241830ee123#3bfff27aaa4246706c5f5156871f0241830ee123"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6905,7 +6905,7 @@ dependencies = [
 [[package]]
 name = "pallet-transporter"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=1fd384b489e816679a95333b3ff3d9a2d2d8b0a1#1fd384b489e816679a95333b3ff3d9a2d2d8b0a1"
+source = "git+https://github.com/subspace/subspace?rev=3bfff27aaa4246706c5f5156871f0241830ee123#3bfff27aaa4246706c5f5156871f0241830ee123"
 dependencies = [
  "domain-runtime-primitives",
  "frame-benchmarking",
@@ -8433,7 +8433,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-subspace"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=1fd384b489e816679a95333b3ff3d9a2d2d8b0a1#1fd384b489e816679a95333b3ff3d9a2d2d8b0a1"
+source = "git+https://github.com/subspace/subspace?rev=3bfff27aaa4246706c5f5156871f0241830ee123#3bfff27aaa4246706c5f5156871f0241830ee123"
 dependencies = [
  "async-trait",
  "futures",
@@ -8473,7 +8473,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-subspace-rpc"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=1fd384b489e816679a95333b3ff3d9a2d2d8b0a1#1fd384b489e816679a95333b3ff3d9a2d2d8b0a1"
+source = "git+https://github.com/subspace/subspace?rev=3bfff27aaa4246706c5f5156871f0241830ee123#3bfff27aaa4246706c5f5156871f0241830ee123"
 dependencies = [
  "async-oneshot",
  "futures",
@@ -8504,7 +8504,7 @@ dependencies = [
 [[package]]
 name = "sc-domains"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=1fd384b489e816679a95333b3ff3d9a2d2d8b0a1#1fd384b489e816679a95333b3ff3d9a2d2d8b0a1"
+source = "git+https://github.com/subspace/subspace?rev=3bfff27aaa4246706c5f5156871f0241830ee123#3bfff27aaa4246706c5f5156871f0241830ee123"
 dependencies = [
  "sc-client-api",
  "sc-executor",
@@ -8843,7 +8843,7 @@ dependencies = [
 [[package]]
 name = "sc-proof-of-time"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=1fd384b489e816679a95333b3ff3d9a2d2d8b0a1#1fd384b489e816679a95333b3ff3d9a2d2d8b0a1"
+source = "git+https://github.com/subspace/subspace?rev=3bfff27aaa4246706c5f5156871f0241830ee123#3bfff27aaa4246706c5f5156871f0241830ee123"
 dependencies = [
  "atomic",
  "core_affinity",
@@ -9065,7 +9065,7 @@ dependencies = [
 [[package]]
 name = "sc-subspace-block-relay"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=1fd384b489e816679a95333b3ff3d9a2d2d8b0a1#1fd384b489e816679a95333b3ff3d9a2d2d8b0a1"
+source = "git+https://github.com/subspace/subspace?rev=3bfff27aaa4246706c5f5156871f0241830ee123#3bfff27aaa4246706c5f5156871f0241830ee123"
 dependencies = [
  "async-channel",
  "async-trait",
@@ -9090,7 +9090,7 @@ dependencies = [
 [[package]]
 name = "sc-subspace-chain-specs"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=1fd384b489e816679a95333b3ff3d9a2d2d8b0a1#1fd384b489e816679a95333b3ff3d9a2d2d8b0a1"
+source = "git+https://github.com/subspace/subspace?rev=3bfff27aaa4246706c5f5156871f0241830ee123#3bfff27aaa4246706c5f5156871f0241830ee123"
 
 [[package]]
 name = "sc-sysinfo"
@@ -9816,7 +9816,7 @@ dependencies = [
 [[package]]
 name = "sp-block-fees"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=1fd384b489e816679a95333b3ff3d9a2d2d8b0a1#1fd384b489e816679a95333b3ff3d9a2d2d8b0a1"
+source = "git+https://github.com/subspace/subspace?rev=3bfff27aaa4246706c5f5156871f0241830ee123#3bfff27aaa4246706c5f5156871f0241830ee123"
 dependencies = [
  "async-trait",
  "domain-runtime-primitives",
@@ -9910,7 +9910,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-subspace"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=1fd384b489e816679a95333b3ff3d9a2d2d8b0a1#1fd384b489e816679a95333b3ff3d9a2d2d8b0a1"
+source = "git+https://github.com/subspace/subspace?rev=3bfff27aaa4246706c5f5156871f0241830ee123#3bfff27aaa4246706c5f5156871f0241830ee123"
 dependencies = [
  "async-trait",
  "log",
@@ -10046,7 +10046,7 @@ dependencies = [
 [[package]]
 name = "sp-domain-digests"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=1fd384b489e816679a95333b3ff3d9a2d2d8b0a1#1fd384b489e816679a95333b3ff3d9a2d2d8b0a1"
+source = "git+https://github.com/subspace/subspace?rev=3bfff27aaa4246706c5f5156871f0241830ee123#3bfff27aaa4246706c5f5156871f0241830ee123"
 dependencies = [
  "parity-scale-codec",
  "sp-runtime",
@@ -10055,7 +10055,7 @@ dependencies = [
 [[package]]
 name = "sp-domains"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=1fd384b489e816679a95333b3ff3d9a2d2d8b0a1#1fd384b489e816679a95333b3ff3d9a2d2d8b0a1"
+source = "git+https://github.com/subspace/subspace?rev=3bfff27aaa4246706c5f5156871f0241830ee123#3bfff27aaa4246706c5f5156871f0241830ee123"
 dependencies = [
  "blake2 0.10.6",
  "domain-runtime-primitives",
@@ -10087,7 +10087,7 @@ dependencies = [
 [[package]]
 name = "sp-domains-fraud-proof"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=1fd384b489e816679a95333b3ff3d9a2d2d8b0a1#1fd384b489e816679a95333b3ff3d9a2d2d8b0a1"
+source = "git+https://github.com/subspace/subspace?rev=3bfff27aaa4246706c5f5156871f0241830ee123#3bfff27aaa4246706c5f5156871f0241830ee123"
 dependencies = [
  "domain-block-preprocessor",
  "domain-runtime-primitives",
@@ -10119,7 +10119,7 @@ dependencies = [
 [[package]]
 name = "sp-executive"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=1fd384b489e816679a95333b3ff3d9a2d2d8b0a1#1fd384b489e816679a95333b3ff3d9a2d2d8b0a1"
+source = "git+https://github.com/subspace/subspace?rev=3bfff27aaa4246706c5f5156871f0241830ee123#3bfff27aaa4246706c5f5156871f0241830ee123"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -10211,7 +10211,7 @@ dependencies = [
 [[package]]
 name = "sp-messenger"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=1fd384b489e816679a95333b3ff3d9a2d2d8b0a1#1fd384b489e816679a95333b3ff3d9a2d2d8b0a1"
+source = "git+https://github.com/subspace/subspace?rev=3bfff27aaa4246706c5f5156871f0241830ee123#3bfff27aaa4246706c5f5156871f0241830ee123"
 dependencies = [
  "frame-support",
  "hash-db",
@@ -10231,7 +10231,7 @@ dependencies = [
 [[package]]
 name = "sp-messenger-host-functions"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=1fd384b489e816679a95333b3ff3d9a2d2d8b0a1#1fd384b489e816679a95333b3ff3d9a2d2d8b0a1"
+source = "git+https://github.com/subspace/subspace?rev=3bfff27aaa4246706c5f5156871f0241830ee123#3bfff27aaa4246706c5f5156871f0241830ee123"
 dependencies = [
  "domain-block-preprocessor",
  "parity-scale-codec",
@@ -10292,7 +10292,7 @@ dependencies = [
 [[package]]
 name = "sp-objects"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=1fd384b489e816679a95333b3ff3d9a2d2d8b0a1#1fd384b489e816679a95333b3ff3d9a2d2d8b0a1"
+source = "git+https://github.com/subspace/subspace?rev=3bfff27aaa4246706c5f5156871f0241830ee123#3bfff27aaa4246706c5f5156871f0241830ee123"
 dependencies = [
  "sp-api",
  "sp-std",
@@ -10480,7 +10480,7 @@ dependencies = [
 [[package]]
 name = "sp-subspace-mmr"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=1fd384b489e816679a95333b3ff3d9a2d2d8b0a1#1fd384b489e816679a95333b3ff3d9a2d2d8b0a1"
+source = "git+https://github.com/subspace/subspace?rev=3bfff27aaa4246706c5f5156871f0241830ee123#3bfff27aaa4246706c5f5156871f0241830ee123"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -10625,7 +10625,7 @@ dependencies = [
 
 [[package]]
 name = "space-acres"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -10813,7 +10813,7 @@ dependencies = [
 [[package]]
 name = "subspace-archiving"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=1fd384b489e816679a95333b3ff3d9a2d2d8b0a1#1fd384b489e816679a95333b3ff3d9a2d2d8b0a1"
+source = "git+https://github.com/subspace/subspace?rev=3bfff27aaa4246706c5f5156871f0241830ee123#3bfff27aaa4246706c5f5156871f0241830ee123"
 dependencies = [
  "parity-scale-codec",
  "rayon",
@@ -10826,7 +10826,7 @@ dependencies = [
 [[package]]
 name = "subspace-core-primitives"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=1fd384b489e816679a95333b3ff3d9a2d2d8b0a1#1fd384b489e816679a95333b3ff3d9a2d2d8b0a1"
+source = "git+https://github.com/subspace/subspace?rev=3bfff27aaa4246706c5f5156871f0241830ee123#3bfff27aaa4246706c5f5156871f0241830ee123"
 dependencies = [
  "blake3",
  "derive_more",
@@ -10849,7 +10849,7 @@ dependencies = [
 [[package]]
 name = "subspace-erasure-coding"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=1fd384b489e816679a95333b3ff3d9a2d2d8b0a1#1fd384b489e816679a95333b3ff3d9a2d2d8b0a1"
+source = "git+https://github.com/subspace/subspace?rev=3bfff27aaa4246706c5f5156871f0241830ee123#3bfff27aaa4246706c5f5156871f0241830ee123"
 dependencies = [
  "kzg",
  "rust-kzg-blst",
@@ -10859,7 +10859,7 @@ dependencies = [
 [[package]]
 name = "subspace-farmer"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=1fd384b489e816679a95333b3ff3d9a2d2d8b0a1#1fd384b489e816679a95333b3ff3d9a2d2d8b0a1"
+source = "git+https://github.com/subspace/subspace?rev=3bfff27aaa4246706c5f5156871f0241830ee123#3bfff27aaa4246706c5f5156871f0241830ee123"
 dependencies = [
  "anyhow",
  "async-lock 3.3.0",
@@ -10917,7 +10917,7 @@ dependencies = [
 [[package]]
 name = "subspace-farmer-components"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=1fd384b489e816679a95333b3ff3d9a2d2d8b0a1#1fd384b489e816679a95333b3ff3d9a2d2d8b0a1"
+source = "git+https://github.com/subspace/subspace?rev=3bfff27aaa4246706c5f5156871f0241830ee123#3bfff27aaa4246706c5f5156871f0241830ee123"
 dependencies = [
  "async-lock 3.3.0",
  "async-trait",
@@ -10948,7 +10948,7 @@ dependencies = [
 [[package]]
 name = "subspace-metrics"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=1fd384b489e816679a95333b3ff3d9a2d2d8b0a1#1fd384b489e816679a95333b3ff3d9a2d2d8b0a1"
+source = "git+https://github.com/subspace/subspace?rev=3bfff27aaa4246706c5f5156871f0241830ee123#3bfff27aaa4246706c5f5156871f0241830ee123"
 dependencies = [
  "actix-web",
  "prometheus",
@@ -10959,7 +10959,7 @@ dependencies = [
 [[package]]
 name = "subspace-networking"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=1fd384b489e816679a95333b3ff3d9a2d2d8b0a1#1fd384b489e816679a95333b3ff3d9a2d2d8b0a1"
+source = "git+https://github.com/subspace/subspace?rev=3bfff27aaa4246706c5f5156871f0241830ee123#3bfff27aaa4246706c5f5156871f0241830ee123"
 dependencies = [
  "async-mutex",
  "async-trait",
@@ -10997,7 +10997,7 @@ dependencies = [
 [[package]]
 name = "subspace-proof-of-space"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=1fd384b489e816679a95333b3ff3d9a2d2d8b0a1#1fd384b489e816679a95333b3ff3d9a2d2d8b0a1"
+source = "git+https://github.com/subspace/subspace?rev=3bfff27aaa4246706c5f5156871f0241830ee123#3bfff27aaa4246706c5f5156871f0241830ee123"
 dependencies = [
  "chacha20",
  "derive_more",
@@ -11010,7 +11010,7 @@ dependencies = [
 [[package]]
 name = "subspace-proof-of-time"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=1fd384b489e816679a95333b3ff3d9a2d2d8b0a1#1fd384b489e816679a95333b3ff3d9a2d2d8b0a1"
+source = "git+https://github.com/subspace/subspace?rev=3bfff27aaa4246706c5f5156871f0241830ee123#3bfff27aaa4246706c5f5156871f0241830ee123"
 dependencies = [
  "aes",
  "subspace-core-primitives",
@@ -11020,7 +11020,7 @@ dependencies = [
 [[package]]
 name = "subspace-rpc-primitives"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=1fd384b489e816679a95333b3ff3d9a2d2d8b0a1#1fd384b489e816679a95333b3ff3d9a2d2d8b0a1"
+source = "git+https://github.com/subspace/subspace?rev=3bfff27aaa4246706c5f5156871f0241830ee123#3bfff27aaa4246706c5f5156871f0241830ee123"
 dependencies = [
  "hex",
  "serde",
@@ -11032,7 +11032,7 @@ dependencies = [
 [[package]]
 name = "subspace-runtime"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=1fd384b489e816679a95333b3ff3d9a2d2d8b0a1#1fd384b489e816679a95333b3ff3d9a2d2d8b0a1"
+source = "git+https://github.com/subspace/subspace?rev=3bfff27aaa4246706c5f5156871f0241830ee123#3bfff27aaa4246706c5f5156871f0241830ee123"
 dependencies = [
  "domain-runtime-primitives",
  "frame-benchmarking",
@@ -11087,7 +11087,7 @@ dependencies = [
 [[package]]
 name = "subspace-runtime-primitives"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=1fd384b489e816679a95333b3ff3d9a2d2d8b0a1#1fd384b489e816679a95333b3ff3d9a2d2d8b0a1"
+source = "git+https://github.com/subspace/subspace?rev=3bfff27aaa4246706c5f5156871f0241830ee123#3bfff27aaa4246706c5f5156871f0241830ee123"
 dependencies = [
  "pallet-transaction-payment",
  "sp-core",
@@ -11099,7 +11099,7 @@ dependencies = [
 [[package]]
 name = "subspace-service"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=1fd384b489e816679a95333b3ff3d9a2d2d8b0a1#1fd384b489e816679a95333b3ff3d9a2d2d8b0a1"
+source = "git+https://github.com/subspace/subspace?rev=3bfff27aaa4246706c5f5156871f0241830ee123#3bfff27aaa4246706c5f5156871f0241830ee123"
 dependencies = [
  "async-trait",
  "cross-domain-message-gossip",
@@ -11176,7 +11176,7 @@ dependencies = [
 [[package]]
 name = "subspace-verification"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=1fd384b489e816679a95333b3ff3d9a2d2d8b0a1#1fd384b489e816679a95333b3ff3d9a2d2d8b0a1"
+source = "git+https://github.com/subspace/subspace?rev=3bfff27aaa4246706c5f5156871f0241830ee123#3bfff27aaa4246706c5f5156871f0241830ee123"
 dependencies = [
  "parity-scale-codec",
  "schnorrkel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "space-acres"
 description = "Space Acres is an opinionated GUI application for farming on Subspace Network"
 license = "0BSD"
-version = "0.1.4"
+version = "0.1.5"
 authors = ["Nazar Mokrynskyi <nazar@mokrynskyi.com>"]
 repository = "https://github.com/subspace/space-acres"
 edition = "2021"
@@ -64,25 +64,25 @@ sc-informant = { git = "https://github.com/subspace/polkadot-sdk", rev = "d6b500
 sc-network = { git = "https://github.com/subspace/polkadot-sdk", rev = "d6b500960579d73c43fc4ef550b703acfa61c4c8", default-features = false }
 sc-service = { git = "https://github.com/subspace/polkadot-sdk", rev = "d6b500960579d73c43fc4ef550b703acfa61c4c8", default-features = false }
 sc-storage-monitor = { git = "https://github.com/subspace/polkadot-sdk", rev = "d6b500960579d73c43fc4ef550b703acfa61c4c8", default-features = false }
-sc-subspace-chain-specs = { git = "https://github.com/subspace/subspace", rev = "1fd384b489e816679a95333b3ff3d9a2d2d8b0a1" }
+sc-subspace-chain-specs = { git = "https://github.com/subspace/subspace", rev = "3bfff27aaa4246706c5f5156871f0241830ee123" }
 semver = "1.0.21"
 serde = { version = "1.0.196", features = ["derive"]}
 serde_json = "1.0.113"
 simple_moving_average = "1.0.2"
 sp-core = { git = "https://github.com/subspace/polkadot-sdk", rev = "d6b500960579d73c43fc4ef550b703acfa61c4c8", default-features = false }
-sp-consensus-subspace = { git = "https://github.com/subspace/subspace", rev = "1fd384b489e816679a95333b3ff3d9a2d2d8b0a1" }
-sp-domains-fraud-proof = { git = "https://github.com/subspace/subspace", rev = "1fd384b489e816679a95333b3ff3d9a2d2d8b0a1" }
+sp-consensus-subspace = { git = "https://github.com/subspace/subspace", rev = "3bfff27aaa4246706c5f5156871f0241830ee123" }
+sp-domains-fraud-proof = { git = "https://github.com/subspace/subspace", rev = "3bfff27aaa4246706c5f5156871f0241830ee123" }
 sp-runtime = { git = "https://github.com/subspace/polkadot-sdk", rev = "d6b500960579d73c43fc4ef550b703acfa61c4c8", default-features = false }
-subspace-core-primitives = { git = "https://github.com/subspace/subspace", rev = "1fd384b489e816679a95333b3ff3d9a2d2d8b0a1" }
-subspace-erasure-coding = { git = "https://github.com/subspace/subspace", rev = "1fd384b489e816679a95333b3ff3d9a2d2d8b0a1" }
-subspace-farmer = { git = "https://github.com/subspace/subspace", rev = "1fd384b489e816679a95333b3ff3d9a2d2d8b0a1", default-features = false }
-subspace-farmer-components = { git = "https://github.com/subspace/subspace", rev = "1fd384b489e816679a95333b3ff3d9a2d2d8b0a1" }
-subspace-networking = { git = "https://github.com/subspace/subspace", rev = "1fd384b489e816679a95333b3ff3d9a2d2d8b0a1" }
-subspace-proof-of-space = { git = "https://github.com/subspace/subspace", rev = "1fd384b489e816679a95333b3ff3d9a2d2d8b0a1" }
-subspace-rpc-primitives = { git = "https://github.com/subspace/subspace", rev = "1fd384b489e816679a95333b3ff3d9a2d2d8b0a1" }
-subspace-runtime = { git = "https://github.com/subspace/subspace", rev = "1fd384b489e816679a95333b3ff3d9a2d2d8b0a1" }
-subspace-runtime-primitives = { git = "https://github.com/subspace/subspace", rev = "1fd384b489e816679a95333b3ff3d9a2d2d8b0a1" }
-subspace-service = { git = "https://github.com/subspace/subspace", rev = "1fd384b489e816679a95333b3ff3d9a2d2d8b0a1" }
+subspace-core-primitives = { git = "https://github.com/subspace/subspace", rev = "3bfff27aaa4246706c5f5156871f0241830ee123" }
+subspace-erasure-coding = { git = "https://github.com/subspace/subspace", rev = "3bfff27aaa4246706c5f5156871f0241830ee123" }
+subspace-farmer = { git = "https://github.com/subspace/subspace", rev = "3bfff27aaa4246706c5f5156871f0241830ee123", default-features = false }
+subspace-farmer-components = { git = "https://github.com/subspace/subspace", rev = "3bfff27aaa4246706c5f5156871f0241830ee123" }
+subspace-networking = { git = "https://github.com/subspace/subspace", rev = "3bfff27aaa4246706c5f5156871f0241830ee123" }
+subspace-proof-of-space = { git = "https://github.com/subspace/subspace", rev = "3bfff27aaa4246706c5f5156871f0241830ee123" }
+subspace-rpc-primitives = { git = "https://github.com/subspace/subspace", rev = "3bfff27aaa4246706c5f5156871f0241830ee123" }
+subspace-runtime = { git = "https://github.com/subspace/subspace", rev = "3bfff27aaa4246706c5f5156871f0241830ee123" }
+subspace-runtime-primitives = { git = "https://github.com/subspace/subspace", rev = "3bfff27aaa4246706c5f5156871f0241830ee123" }
+subspace-service = { git = "https://github.com/subspace/subspace", rev = "3bfff27aaa4246706c5f5156871f0241830ee123" }
 supports-color = "2.1.0"
 thiserror = "1.0.56"
 thread-priority = "0.16.0"


### PR DESCRIPTION
This improves plot caching behavior and related memory usage on Windows.

On Windows plot caching is now disabled for farms over 2T.