### PR TITLE
Fix cargo nextest by allowing to upgrade dependencies comparing to lock file

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -256,6 +256,8 @@ jobs:
       - name: Install cargo-nextest
         uses: taiki-e/cache-cargo-install-action@1b76958d032c4d048c599f9fdfa48abe804d6319 # v1.2.2
         with:
+          # TODO: Remove when cargo-nextest 0.9.68+ is out and has crates compatible with latest nightly in lock file
+          locked: false
           tool: cargo-nextest
 
       - name: cargo nextest run --locked


### PR DESCRIPTION
Otherwise it is not compatible with newer Rust compiler