### PR TITLE
Support legacy CPUs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,8 @@ jobs:
           - os: ubuntu-22.04
             target: x86_64-unknown-linux-gnu
             suffix: ubuntu-x86_64-skylake-${{ github.ref_name }}
-            rustflags: "-C target-cpu=skylake"
+            modern-rustflags: "-C target-cpu=skylake"
+            rustflags: "-C target-cpu=x86-64-v2"
           # TODO: Package for more Linux distributions/packaging formats/architectures and macOS
           #- os: ubuntu-22.04
           #  target: aarch64-unknown-linux-gnu
@@ -38,10 +39,10 @@ jobs:
           - os: windows-2022
             target: x86_64-pc-windows-msvc
             suffix: windows-x86_64-skylake-${{ github.ref_name }}
-            rustflags: "-C target-cpu=skylake"
+            modern-rustflags: "-C target-cpu=skylake"
+            rustflags: "-C target-cpu=x86-64-v2"
+      fail-fast: false
     runs-on: ${{ matrix.build.os }}
-    env:
-      RUSTFLAGS: ${{ matrix.build.rustflags }}
 
     steps:
       - name: Checkout
@@ -126,10 +127,29 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cargo-
 
-      - name: Build app (Linux and Windows)
+      - name: Build app (Linux, modern)
+        env:
+          RUSTFLAGS: ${{ matrix.build.modern-rustflags }}
+        run: |
+          cargo -Zgitoxide -Zgit build --locked -Z build-std --target ${{ matrix.build.target }} --profile production
+          mv target/${{ matrix.build.target }}/production/space-acres target/${{ matrix.build.target }}/production/space-acres-modern
+        if: runner.os == 'Linux' && matrix.build.modern-rustflags
+
+      - name: Build app (Windows, modern)
+        env:
+          RUSTFLAGS: ${{ matrix.build.modern-rustflags }}
+        run: |
+          cargo -Zgitoxide -Zgit build --locked -Z build-std --target ${{ matrix.build.target }} --profile production
+          Move-Item -Path target\${{ matrix.build.target }}\production\space-acres.exe -Destination target\${{ matrix.build.target }}\production\space-acres-modern.exe
+        if: runner.os == 'Windows' && matrix.build.modern-rustflags
+
+      - name: Build app (Linux and Windows, normal)
+        env:
+          RUSTFLAGS: ${{ matrix.build.rustflags }}
         run: cargo -Zgitoxide -Zgit build --locked -Z build-std --target ${{ matrix.build.target }} --profile production
         if: runner.os != 'macOS'
 
+      # TODO: Remove special case once `numa` feature of farmer works properly on macOS
       - name: Build app (macOS)
         run: cargo -Zgitoxide -Zgit build --locked -Z build-std --target ${{ matrix.build.target }} --profile production --no-default-features
         if: runner.os == 'macOS'
@@ -206,7 +226,30 @@ jobs:
           tool: cargo-deb
         if: runner.os == 'Linux'
 
-      - name: Package (Linux)
+      - name: Package (Linux, with modern)
+        run: |
+          # Build Debian package
+          cargo deb --target ${{ matrix.build.target }} --profile production --no-build --no-strip --variant=modern
+          
+          # And build AppImage as well
+          wget https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage
+          wget https://raw.githubusercontent.com/linuxdeploy/linuxdeploy-plugin-gtk/3b67a1d1c1b0c8268f57f2bce40fe2d33d409cea/linuxdeploy-plugin-gtk.sh
+          chmod +x linuxdeploy*.AppImage linuxdeploy-plugin-gtk.sh
+          NO_STRIP=1 ./linuxdeploy-x86_64.AppImage \
+              --appdir AppDir \
+              --plugin gtk \
+              --executable target/${{ matrix.build.target }}/production/space-acres \
+              --executable target/${{ matrix.build.target }}/production/space-acres-modern \
+              --desktop-file res/linux/space-acres.desktop \
+              --icon-file res/linux/space-acres.png \
+              --output appimage
+          
+          # Rename AppImage to be consistent with other files
+          version=$(grep -Po 'version = "\K.*?(?=")' -m 1 Cargo.toml)
+          mv Space_Acres-x86_64.AppImage space-acres-$version-x86_64.AppImage
+        if: runner.os == 'Linux' && matrix.build.modern-rustflags
+
+      - name: Package (Linux, without modern)
         run: |
           # Build Debian package
           cargo deb --target ${{ matrix.build.target }} --profile production --no-build --no-strip
@@ -226,7 +269,7 @@ jobs:
           # Rename AppImage to be consistent with other files
           version=$(grep -Po 'version = "\K.*?(?=")' -m 1 Cargo.toml)
           mv Space_Acres-x86_64.AppImage space-acres-$version-x86_64.AppImage
-        if: runner.os == 'Linux'
+        if: runner.os == 'Linux' && !matrix.build.modern-rustflags
 
       - name: Upload installer to artifacts (Linux)
         uses: actions/upload-artifact@83fd05a356d7e2593de66fc9913b3002723633cb # @v3.1.1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,12 @@ assets = [
     ["res/linux/space-acres.png", "/usr/share/pixmaps/space-acres.png", "644"],
 ]
 
+[package.metadata.deb.variants.modern]
+name = "space-acres"
+merge-assets.append = [
+    ["target/release/space-acres-modern", "/usr/bin/space-acres-modern", "755"],
+]
+
 # TODO: Menu shortcut will not be generated automatically in case of re-init: https://github.com/volks73/cargo-wix/issues/141
 [package.metadata.wix]
 # Custom location to keep the root of the project cleaner

--- a/res/windows/wix/space-acres.wxs
+++ b/res/windows/wix/space-acres.wxs
@@ -129,6 +129,14 @@
                                 Source='$(var.CargoTargetBinDir)\space-acres.exe'
                                 KeyPath='yes'/>
                         </Component>
+                        <Component Id='binary1' Guid='*'>
+                            <File
+                                Id='space_acres_modern.exe'
+                                Name='space-acres-modern.exe'
+                                DiskId='1'
+                                Source='$(var.CargoTargetBinDir)\space-acres-modern.exe'
+                                KeyPath='yes'/>
+                        </Component>
                         <!-- TODO: Next block is for cleanup after 0.1.5 -> 0.1.6 upgrade, remove once enough time has passed -->
                         <Component Id="PcreCleanup" Guid="64d35867-a002-4ac5-8704-ba15236c4ca1">
                           <RemoveFile Id="pcre2_16.dll" Name="pcre2-16.dll" On="both" />
@@ -372,6 +380,7 @@
             <!--<ComponentRef Id='License'/>-->
 
             <ComponentRef Id='binary0'/>
+            <ComponentRef Id='binary1'/>
             <ComponentRef Id='PcreCleanup'/>
             <ComponentRef Id='gtk4_gdbus.exe'/>
             <ComponentRef Id='gtk4_gspawn_win64_helper.exe'/>

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
-#![feature(const_option, trait_alias, try_blocks)]
+#![feature(const_option, let_chains, trait_alias, try_blocks)]
 
 mod backend;
 mod frontend;
@@ -848,6 +848,8 @@ impl Cli {
     fn supervisor(mut self) -> io::Result<()> {
         let maybe_app_data_dir = Self::app_data_dir();
 
+        let program = Self::child_program()?;
+
         loop {
             let mut args = vec!["--child-process".to_string()];
             if self.startup {
@@ -863,9 +865,9 @@ impl Cli {
                 .then_some(maybe_app_data_dir.as_ref())
                 .flatten()
             {
-                let mut expression = cmd(env::current_exe()?, args)
+                let mut expression = cmd(&program, args)
                     .stderr_to_stdout()
-                    // We use non-zero status codes and they don't mean error necessarily
+                    // We use non-zero status codes, and they don't mean error necessarily
                     .unchecked()
                     .reader()?;
 
@@ -917,7 +919,7 @@ impl Cli {
                     }
                 }
             } else if WINDOWS_SUBSYSTEM_WINDOWS {
-                cmd(env::current_exe()?, args)
+                cmd(&program, args)
                     .stdin_null()
                     .stdout_null()
                     .stderr_null()
@@ -927,7 +929,7 @@ impl Cli {
                     .status
             } else {
                 eprintln!("App data directory doesn't exist, not creating log file");
-                cmd(env::current_exe()?, args)
+                cmd(&program, args)
                     // We use non-zero status codes and they don't mean error necessarily
                     .unchecked()
                     .run()?
@@ -987,6 +989,50 @@ impl Cli {
             #[cfg(unix)]
             Some(0o600),
         )
+    }
+
+    #[cfg(target_arch = "x86_64")]
+    fn child_program() -> io::Result<PathBuf> {
+        let program = env::current_exe()?;
+
+        if !std::arch::is_x86_feature_detected!("xsavec") {
+            return Ok(program);
+        }
+
+        let mut maybe_extension = program.extension();
+        let Some(file_name) = program.file_stem() else {
+            return Ok(program);
+        };
+
+        let mut file_name = file_name.to_os_string();
+
+        if let Some(extension) = maybe_extension
+            && extension != "exe"
+        {
+            file_name = program
+                .file_name()
+                .expect("Checked above; qed")
+                .to_os_string();
+            maybe_extension = None;
+        }
+
+        file_name.push("-modern");
+        if let Some(extension) = maybe_extension {
+            file_name.push(".");
+            file_name.push(extension);
+        }
+        let mut modern_program = program.clone();
+        modern_program.set_file_name(file_name);
+        if modern_program.exists() {
+            Ok(modern_program)
+        } else {
+            Ok(program)
+        }
+    }
+
+    #[cfg(not(target_arch = "x86_64"))]
+    fn child_program() -> io::Result<PathBuf> {
+        env::current_exe()
     }
 }
 


### PR DESCRIPTION
This change brings support for x86-64-v2 CPUs by shipping 2 binaries:
* normal binary is that is built for x86-64-v2, new default
* modern binary is that is build skylake

When application starts, it will do check for supported instructions and if CPU appears to support instructions that only Skylake and newer processors support, it will pick modern version of a binary to as a child process, otherwise it will continue with the default one.

Fixes https://github.com/subspace/space-acres/issues/135, fixes https://github.com/subspace/space-acres/issues/132