### PR TITLE
Replace `subspace-runtime` with `subspace-fake-runtime-api`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -399,20 +399,6 @@ dependencies = [
 
 [[package]]
 name = "aquamarine"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1da02abba9f9063d786eab1509833ebb2fac0f966862ca59439c76b9c566760"
-dependencies = [
- "include_dir",
- "itertools 0.10.5",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "aquamarine"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21cc1548309245035eb18aa7f0967da6bc65587005170c56e6ef2788a4cf3f4e"
@@ -923,6 +909,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479db852db25d9dbf6204e6cb6253698f175c15726470f78af0d918e99d6156e"
 dependencies = [
  "event-listener 2.5.3",
+]
+
+[[package]]
+name = "async-nats"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eea7b126ebfa4db78e9e788b2a792b6329f35b4f2fdd56dbc646dedc2beec7a5"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures",
+ "memchr",
+ "nkeys",
+ "nuid",
+ "once_cell",
+ "portable-atomic",
+ "rand",
+ "regex",
+ "ring 0.17.8",
+ "rustls-native-certs 0.7.0",
+ "rustls-pemfile 2.1.2",
+ "rustls-webpki 0.102.3",
+ "serde",
+ "serde_json",
+ "serde_nanos",
+ "serde_repr",
+ "thiserror",
+ "time",
+ "tokio",
+ "tokio-rustls 0.25.0",
+ "tracing",
+ "tryhard",
+ "url",
 ]
 
 [[package]]
@@ -1442,15 +1461,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "build-helper"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdce191bf3fa4995ce948c8c83b4640a1745457a149e73c6db75b4ffe36aad5f"
-dependencies = [
- "semver 0.6.0",
-]
-
-[[package]]
 name = "bumpalo"
 version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1537,38 +1547,6 @@ dependencies = [
  "glib-sys",
  "libc",
  "system-deps",
-]
-
-[[package]]
-name = "camino"
-version = "1.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c59e92b5a388f549b863a7bea62612c09f24c8393560709a54558a9abdfb3b9c"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "cargo-platform"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24b1f0365a6c6bb4020cd05806fd0d33c44d38046b8bd7f0e40814b9763cabfc"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "cargo_metadata"
-version = "0.15.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eee4243f1f26fc7a42710e7439c149e2b10b05472f88090acce52632f231a73a"
-dependencies = [
- "camino",
- "cargo-platform",
- "semver 1.0.22",
- "serde",
- "serde_json",
- "thiserror",
 ]
 
 [[package]]
@@ -1846,16 +1824,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "codespan-reporting"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
-dependencies = [
- "termcolor",
- "unicode-width",
-]
-
-[[package]]
 name = "colorchoice"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1890,19 +1858,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
 dependencies = [
  "crossbeam-utils",
-]
-
-[[package]]
-name = "console"
-version = "0.15.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e1f83fc076bd6dd27517eacdf25fef6c4dfe5f1d7448bafaaf3a26f13b5e4eb"
-dependencies = [
- "encode_unicode",
- "lazy_static",
- "libc",
- "unicode-width",
- "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2062,7 +2017,7 @@ dependencies = [
  "gimli 0.27.3",
  "hashbrown 0.13.2",
  "log",
- "regalloc2 0.6.1",
+ "regalloc2",
  "smallvec",
  "target-lexicon",
 ]
@@ -2190,7 +2145,7 @@ checksum = "7059fff8937831a9ae6f0fe4d658ffabf58f2ca96aa9dec1c889f936f705f216"
 [[package]]
 name = "cross-domain-message-gossip"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=1d7ecd667be10409bfa083663b7d097848ddf08d#1d7ecd667be10409bfa083663b7d097848ddf08d"
+source = "git+https://github.com/subspace/subspace?rev=3494834414356226e10ebf7288293eda934baf6a#3494834414356226e10ebf7288293eda934baf6a"
 dependencies = [
  "futures",
  "parity-scale-codec",
@@ -2331,50 +2286,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cxx"
-version = "1.0.121"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21db378d04296a84d8b7d047c36bb3954f0b46529db725d7e62fb02f9ba53ccc"
-dependencies = [
- "cc",
- "cxxbridge-flags",
- "cxxbridge-macro",
- "link-cplusplus",
-]
-
-[[package]]
-name = "cxx-build"
-version = "1.0.121"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e5262a7fa3f0bae2a55b767c223ba98032d7c328f5c13fa5cdc980b77fc0658"
-dependencies = [
- "cc",
- "codespan-reporting",
- "once_cell",
- "proc-macro2",
- "quote",
- "scratch",
- "syn 2.0.60",
-]
-
-[[package]]
-name = "cxxbridge-flags"
-version = "1.0.121"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be8dcadd2e2fb4a501e1d9e93d6e88e6ea494306d8272069c92d5a9edf8855c0"
-
-[[package]]
-name = "cxxbridge-macro"
-version = "1.0.121"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad08a837629ad949b73d032c637653d069e909cffe4ee7870b02301939ce39cc"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.60",
-]
-
-[[package]]
 name = "dark-light"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2442,6 +2353,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f55bf8e7b65898637379c1b74eb1551107c8294ed26d855ceb9fd1a09cfc9bc0"
 dependencies = [
  "const-oid",
+ "pem-rfc7468",
  "zeroize",
 ]
 
@@ -2480,6 +2392,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
 dependencies = [
  "powerfmt",
+ "serde",
 ]
 
 [[package]]
@@ -2714,7 +2627,7 @@ dependencies = [
 [[package]]
 name = "domain-block-preprocessor"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=1d7ecd667be10409bfa083663b7d097848ddf08d#1d7ecd667be10409bfa083663b7d097848ddf08d"
+source = "git+https://github.com/subspace/subspace?rev=3494834414356226e10ebf7288293eda934baf6a#3494834414356226e10ebf7288293eda934baf6a"
 dependencies = [
  "async-trait",
  "domain-runtime-primitives",
@@ -2743,7 +2656,7 @@ dependencies = [
 [[package]]
 name = "domain-runtime-primitives"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=1d7ecd667be10409bfa083663b7d097848ddf08d#1d7ecd667be10409bfa083663b7d097848ddf08d"
+source = "git+https://github.com/subspace/subspace?rev=3494834414356226e10ebf7288293eda934baf6a#3494834414356226e10ebf7288293eda934baf6a"
 dependencies = [
  "fp-account",
  "frame-support",
@@ -2846,6 +2759,7 @@ dependencies = [
  "rand_core 0.6.4",
  "serde",
  "sha2 0.10.8",
+ "signature",
  "subtle 2.5.0",
  "zeroize",
 ]
@@ -2889,12 +2803,6 @@ dependencies = [
  "subtle 2.5.0",
  "zeroize",
 ]
-
-[[package]]
-name = "encode_unicode"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
 name = "encoding_rs"
@@ -3098,12 +3006,6 @@ name = "fallible-iterator"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
-
-[[package]]
-name = "fallible-iterator"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
 
 [[package]]
 name = "fastrand"
@@ -3320,7 +3222,7 @@ dependencies = [
 [[package]]
 name = "fp-account"
 version = "1.0.0-dev"
-source = "git+https://github.com/subspace/frontier?rev=4354330f71535a5459b8e3c7e7ed0c0d612b5e0e#4354330f71535a5459b8e3c7e7ed0c0d612b5e0e"
+source = "git+https://github.com/subspace/frontier?rev=1fe202805f3a3158b278386200ca6761f22b271e#1fe202805f3a3158b278386200ca6761f22b271e"
 dependencies = [
  "hex",
  "impl-serde",
@@ -3368,25 +3270,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "frame-executive"
-version = "28.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=44d742b90e7852aed1f08ab5299d5d88cfa1c6ed#44d742b90e7852aed1f08ab5299d5d88cfa1c6ed"
-dependencies = [
- "aquamarine 0.3.3",
- "frame-support",
- "frame-system",
- "frame-try-runtime",
- "log",
- "parity-scale-codec",
- "scale-info",
- "sp-core",
- "sp-io",
- "sp-runtime",
- "sp-std",
- "sp-tracing",
-]
-
-[[package]]
 name = "frame-metadata"
 version = "16.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3403,7 +3286,7 @@ name = "frame-support"
 version = "28.0.0"
 source = "git+https://github.com/subspace/polkadot-sdk?rev=44d742b90e7852aed1f08ab5299d5d88cfa1c6ed#44d742b90e7852aed1f08ab5299d5d88cfa1c6ed"
 dependencies = [
- "aquamarine 0.5.0",
+ "aquamarine",
  "array-bytes 6.2.2",
  "bitflags 1.3.2",
  "docify",
@@ -3501,39 +3384,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "frame-system-benchmarking"
-version = "28.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=44d742b90e7852aed1f08ab5299d5d88cfa1c6ed#44d742b90e7852aed1f08ab5299d5d88cfa1c6ed"
-dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
- "parity-scale-codec",
- "scale-info",
- "sp-core",
- "sp-runtime",
- "sp-std",
-]
-
-[[package]]
 name = "frame-system-rpc-runtime-api"
 version = "26.0.0"
 source = "git+https://github.com/subspace/polkadot-sdk?rev=44d742b90e7852aed1f08ab5299d5d88cfa1c6ed#44d742b90e7852aed1f08ab5299d5d88cfa1c6ed"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
-]
-
-[[package]]
-name = "frame-try-runtime"
-version = "0.34.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=44d742b90e7852aed1f08ab5299d5d88cfa1c6ed#44d742b90e7852aed1f08ab5299d5d88cfa1c6ed"
-dependencies = [
- "frame-support",
- "parity-scale-codec",
- "sp-api",
- "sp-runtime",
- "sp-std",
 ]
 
 [[package]]
@@ -3882,7 +3738,7 @@ version = "0.27.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c80984affa11d98d1b88b66ac8853f143217b399d3c74116778ff8fdb4ed2e"
 dependencies = [
- "fallible-iterator 0.2.0",
+ "fallible-iterator",
  "indexmap 1.9.3",
  "stable_deref_trait",
 ]
@@ -3892,10 +3748,6 @@ name = "gimli"
 version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
-dependencies = [
- "fallible-iterator 0.3.0",
- "stable_deref_trait",
-]
 
 [[package]]
 name = "gio"
@@ -4969,15 +4821,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "itertools"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
-dependencies = [
- "either",
-]
-
-[[package]]
 name = "itoa"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5305,17 +5148,17 @@ dependencies = [
  "libp2p-core 0.41.2",
  "libp2p-dns 0.41.1",
  "libp2p-gossipsub",
- "libp2p-identify 0.44.1",
+ "libp2p-identify 0.44.2",
  "libp2p-identity 0.2.8",
  "libp2p-kad 0.45.3",
  "libp2p-mdns 0.45.1",
  "libp2p-metrics 0.14.1",
  "libp2p-noise 0.44.0",
- "libp2p-ping 0.44.0",
+ "libp2p-ping 0.44.1",
  "libp2p-plaintext",
  "libp2p-quic 0.10.2",
- "libp2p-request-response 0.26.1",
- "libp2p-swarm 0.44.1",
+ "libp2p-request-response 0.26.2",
+ "libp2p-swarm 0.44.2",
  "libp2p-tcp 0.41.0",
  "libp2p-upnp",
  "libp2p-yamux 0.45.1",
@@ -5345,7 +5188,7 @@ checksum = "107b238b794cb83ab53b74ad5dcf7cca3200899b72fe662840cfb52f5b0a32e6"
 dependencies = [
  "libp2p-core 0.41.2",
  "libp2p-identity 0.2.8",
- "libp2p-swarm 0.44.1",
+ "libp2p-swarm 0.44.2",
  "void",
 ]
 
@@ -5362,8 +5205,8 @@ dependencies = [
  "instant",
  "libp2p-core 0.41.2",
  "libp2p-identity 0.2.8",
- "libp2p-request-response 0.26.1",
- "libp2p-swarm 0.44.1",
+ "libp2p-request-response 0.26.2",
+ "libp2p-swarm 0.44.2",
  "quick-protobuf",
  "quick-protobuf-codec 0.2.0",
  "rand",
@@ -5390,7 +5233,7 @@ checksum = "c7cd50a78ccfada14de94cbacd3ce4b0138157f376870f13d3a8422cd075b4fd"
 dependencies = [
  "libp2p-core 0.41.2",
  "libp2p-identity 0.2.8",
- "libp2p-swarm 0.44.1",
+ "libp2p-swarm 0.44.2",
  "void",
 ]
 
@@ -5500,7 +5343,7 @@ dependencies = [
  "instant",
  "libp2p-core 0.41.2",
  "libp2p-identity 0.2.8",
- "libp2p-swarm 0.44.1",
+ "libp2p-swarm 0.44.2",
  "prometheus-client 0.22.2",
  "quick-protobuf",
  "quick-protobuf-codec 0.3.1",
@@ -5537,9 +5380,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-identify"
-version = "0.44.1"
+version = "0.44.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20499a945d2f0221fdc6269b3848892c0f370d2ee3e19c7f65a29d8f860f6126"
+checksum = "b5d635ebea5ca0c3c3e77d414ae9b67eccf2a822be06091b9c1a0d13029a1e2f"
 dependencies = [
  "asynchronous-codec 0.7.0",
  "either",
@@ -5548,7 +5391,7 @@ dependencies = [
  "futures-timer",
  "libp2p-core 0.41.2",
  "libp2p-identity 0.2.8",
- "libp2p-swarm 0.44.1",
+ "libp2p-swarm 0.44.2",
  "lru 0.12.3",
  "quick-protobuf",
  "quick-protobuf-codec 0.3.1",
@@ -5640,7 +5483,7 @@ dependencies = [
  "instant",
  "libp2p-core 0.41.2",
  "libp2p-identity 0.2.8",
- "libp2p-swarm 0.44.1",
+ "libp2p-swarm 0.44.2",
  "quick-protobuf",
  "quick-protobuf-codec 0.3.1",
  "rand",
@@ -5686,7 +5529,7 @@ dependencies = [
  "if-watch",
  "libp2p-core 0.41.2",
  "libp2p-identity 0.2.8",
- "libp2p-swarm 0.44.1",
+ "libp2p-swarm 0.44.2",
  "rand",
  "smallvec",
  "socket2 0.5.7",
@@ -5719,11 +5562,11 @@ dependencies = [
  "instant",
  "libp2p-core 0.41.2",
  "libp2p-gossipsub",
- "libp2p-identify 0.44.1",
+ "libp2p-identify 0.44.2",
  "libp2p-identity 0.2.8",
  "libp2p-kad 0.45.3",
- "libp2p-ping 0.44.0",
- "libp2p-swarm 0.44.1",
+ "libp2p-ping 0.44.1",
+ "libp2p-swarm 0.44.2",
  "pin-project",
  "prometheus-client 0.22.2",
 ]
@@ -5796,9 +5639,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-ping"
-version = "0.44.0"
+version = "0.44.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76b94ee41bd8c294194fe608851e45eb98de26fe79bc7913838cbffbfe8c7ce2"
+checksum = "a1de5a6cf64fba7f7e8f2102711c9c6c043a8e56b86db8cd306492c517da3fb3"
 dependencies = [
  "either",
  "futures",
@@ -5806,7 +5649,7 @@ dependencies = [
  "instant",
  "libp2p-core 0.41.2",
  "libp2p-identity 0.2.8",
- "libp2p-swarm 0.44.1",
+ "libp2p-swarm 0.44.2",
  "rand",
  "tracing",
  "void",
@@ -5892,9 +5735,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-request-response"
-version = "0.26.1"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e12823250fe0c45bdddea6eefa2be9a609aff1283ff4e1d8a294fdbb89572f6f"
+checksum = "6946e5456240b3173187cc37a17cb40c3cd1f7138c76e2c773e0d792a42a8de1"
 dependencies = [
  "async-trait",
  "futures",
@@ -5903,7 +5746,7 @@ dependencies = [
  "instant",
  "libp2p-core 0.41.2",
  "libp2p-identity 0.2.8",
- "libp2p-swarm 0.44.1",
+ "libp2p-swarm 0.44.2",
  "rand",
  "smallvec",
  "tracing",
@@ -5933,9 +5776,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-swarm"
-version = "0.44.1"
+version = "0.44.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e92532fc3c4fb292ae30c371815c9b10103718777726ea5497abc268a4761866"
+checksum = "80cae6cb75f89dbca53862f9ebe0b9f463aa7b302762fcfaafb9e51dcc9b0f7e"
 dependencies = [
  "either",
  "fnv",
@@ -5944,7 +5787,8 @@ dependencies = [
  "instant",
  "libp2p-core 0.41.2",
  "libp2p-identity 0.2.8",
- "libp2p-swarm-derive 0.34.1",
+ "libp2p-swarm-derive 0.34.2",
+ "lru 0.12.3",
  "multistream-select 0.13.0",
  "once_cell",
  "rand",
@@ -5967,11 +5811,11 @@ dependencies = [
 
 [[package]]
 name = "libp2p-swarm-derive"
-version = "0.34.1"
+version = "0.34.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b644268b4acfdaa6a6100b31226ee7a36d96ab4c43287d113bfd2308607d8b6f"
+checksum = "5daceb9dd908417b6dfcfe8e94098bc4aac54500c282e78120b885dadc09b999"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.60",
@@ -6050,15 +5894,15 @@ dependencies = [
 
 [[package]]
 name = "libp2p-upnp"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49cc89949bf0e06869297cd4fe2c132358c23fe93e76ad43950453df4da3d35"
+checksum = "cccf04b0e3ff3de52d07d5fd6c3b061d0e7f908ffc683c32d9638caedce86fc8"
 dependencies = [
  "futures",
  "futures-timer",
  "igd-next",
  "libp2p-core 0.41.2",
- "libp2p-swarm 0.44.1",
+ "libp2p-swarm 0.44.2",
  "tokio",
  "tracing",
  "void",
@@ -6192,15 +6036,6 @@ dependencies = [
  "cc",
  "pkg-config",
  "vcpkg",
-]
-
-[[package]]
-name = "link-cplusplus"
-version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d240c6f7e1ba3a28b0249f774e6a9dd0175054b52dfbb61b16eb8505c3785c9"
-dependencies = [
- "cc",
 ]
 
 [[package]]
@@ -6923,6 +6758,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "nkeys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc522a19199a0795776406619aa6aa78e1e55690fbeb3181b8db5265fd0e89ce"
+dependencies = [
+ "data-encoding",
+ "ed25519",
+ "ed25519-dalek",
+ "getrandom 0.2.14",
+ "log",
+ "rand",
+ "signatory",
+]
+
+[[package]]
 name = "no-std-compat"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6964,6 +6814,15 @@ checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
 dependencies = [
  "overload",
  "winapi",
+]
+
+[[package]]
+name = "nuid"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc895af95856f929163a0aa20c26a78d26bfdc839f51b9d5aa7a5b79e52b7e83"
+dependencies = [
+ "rand",
 ]
 
 [[package]]
@@ -7224,21 +7083,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "orml-vesting"
-version = "0.9.1"
-source = "git+https://github.com/subspace/subspace?rev=1d7ecd667be10409bfa083663b7d097848ddf08d#1d7ecd667be10409bfa083663b7d097848ddf08d"
-dependencies = [
- "frame-support",
- "frame-system",
- "parity-scale-codec",
- "scale-info",
- "serde",
- "sp-io",
- "sp-runtime",
- "sp-std",
-]
-
-[[package]]
 name = "os_pipe"
 version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7266,7 +7110,6 @@ version = "28.0.0"
 source = "git+https://github.com/subspace/polkadot-sdk?rev=44d742b90e7852aed1f08ab5299d5d88cfa1c6ed#44d742b90e7852aed1f08ab5299d5d88cfa1c6ed"
 dependencies = [
  "docify",
- "frame-benchmarking",
  "frame-support",
  "frame-system",
  "log",
@@ -7274,52 +7117,6 @@ dependencies = [
  "scale-info",
  "sp-runtime",
  "sp-std",
-]
-
-[[package]]
-name = "pallet-domains"
-version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=1d7ecd667be10409bfa083663b7d097848ddf08d#1d7ecd667be10409bfa083663b7d097848ddf08d"
-dependencies = [
- "domain-runtime-primitives",
- "frame-benchmarking",
- "frame-support",
- "frame-system",
- "log",
- "pallet-balances",
- "parity-scale-codec",
- "scale-info",
- "sp-consensus-slots",
- "sp-consensus-subspace",
- "sp-core",
- "sp-domains",
- "sp-domains-fraud-proof",
- "sp-io",
- "sp-runtime",
- "sp-std",
- "sp-version",
- "subspace-core-primitives",
- "subspace-runtime-primitives",
-]
-
-[[package]]
-name = "pallet-messenger"
-version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=1d7ecd667be10409bfa083663b7d097848ddf08d#1d7ecd667be10409bfa083663b7d097848ddf08d"
-dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
- "log",
- "parity-scale-codec",
- "scale-info",
- "sp-core",
- "sp-domains",
- "sp-messenger",
- "sp-mmr-primitives",
- "sp-runtime",
- "sp-subspace-mmr",
- "sp-trie",
 ]
 
 [[package]]
@@ -7338,138 +7135,6 @@ dependencies = [
  "sp-mmr-primitives",
  "sp-runtime",
  "sp-std",
-]
-
-[[package]]
-name = "pallet-offences-subspace"
-version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=1d7ecd667be10409bfa083663b7d097848ddf08d#1d7ecd667be10409bfa083663b7d097848ddf08d"
-dependencies = [
- "frame-support",
- "frame-system",
- "parity-scale-codec",
- "scale-info",
- "sp-consensus-subspace",
- "sp-runtime",
- "sp-std",
-]
-
-[[package]]
-name = "pallet-rewards"
-version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=1d7ecd667be10409bfa083663b7d097848ddf08d#1d7ecd667be10409bfa083663b7d097848ddf08d"
-dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
- "log",
- "parity-scale-codec",
- "scale-info",
- "serde",
- "sp-core",
- "sp-runtime",
- "subspace-runtime-primitives",
-]
-
-[[package]]
-name = "pallet-runtime-configs"
-version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=1d7ecd667be10409bfa083663b7d097848ddf08d#1d7ecd667be10409bfa083663b7d097848ddf08d"
-dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
- "parity-scale-codec",
- "scale-info",
- "sp-runtime",
- "sp-std",
-]
-
-[[package]]
-name = "pallet-subspace"
-version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=1d7ecd667be10409bfa083663b7d097848ddf08d#1d7ecd667be10409bfa083663b7d097848ddf08d"
-dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
- "log",
- "parity-scale-codec",
- "scale-info",
- "schnorrkel",
- "serde",
- "sp-consensus-slots",
- "sp-consensus-subspace",
- "sp-core",
- "sp-runtime",
- "sp-std",
- "subspace-core-primitives",
- "subspace-runtime-primitives",
- "subspace-verification",
-]
-
-[[package]]
-name = "pallet-subspace-mmr"
-version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=1d7ecd667be10409bfa083663b7d097848ddf08d#1d7ecd667be10409bfa083663b7d097848ddf08d"
-dependencies = [
- "frame-support",
- "frame-system",
- "parity-scale-codec",
- "scale-info",
- "sp-core",
- "sp-mmr-primitives",
- "sp-runtime",
- "sp-std",
- "sp-subspace-mmr",
-]
-
-[[package]]
-name = "pallet-sudo"
-version = "28.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=44d742b90e7852aed1f08ab5299d5d88cfa1c6ed#44d742b90e7852aed1f08ab5299d5d88cfa1c6ed"
-dependencies = [
- "docify",
- "frame-benchmarking",
- "frame-support",
- "frame-system",
- "parity-scale-codec",
- "scale-info",
- "sp-io",
- "sp-runtime",
- "sp-std",
-]
-
-[[package]]
-name = "pallet-timestamp"
-version = "27.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=44d742b90e7852aed1f08ab5299d5d88cfa1c6ed#44d742b90e7852aed1f08ab5299d5d88cfa1c6ed"
-dependencies = [
- "docify",
- "frame-benchmarking",
- "frame-support",
- "frame-system",
- "log",
- "parity-scale-codec",
- "scale-info",
- "sp-inherents",
- "sp-io",
- "sp-runtime",
- "sp-std",
- "sp-storage",
- "sp-timestamp",
-]
-
-[[package]]
-name = "pallet-transaction-fees"
-version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=1d7ecd667be10409bfa083663b7d097848ddf08d#1d7ecd667be10409bfa083663b7d097848ddf08d"
-dependencies = [
- "frame-support",
- "frame-system",
- "parity-scale-codec",
- "scale-info",
- "subspace-runtime-primitives",
 ]
 
 [[package]]
@@ -7514,40 +7179,6 @@ dependencies = [
  "sp-api",
  "sp-runtime",
  "sp-weights",
-]
-
-[[package]]
-name = "pallet-transporter"
-version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=1d7ecd667be10409bfa083663b7d097848ddf08d#1d7ecd667be10409bfa083663b7d097848ddf08d"
-dependencies = [
- "domain-runtime-primitives",
- "frame-benchmarking",
- "frame-support",
- "frame-system",
- "parity-scale-codec",
- "scale-info",
- "sp-core",
- "sp-domains",
- "sp-messenger",
- "sp-runtime",
- "sp-std",
-]
-
-[[package]]
-name = "pallet-utility"
-version = "28.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=44d742b90e7852aed1f08ab5299d5d88cfa1c6ed#44d742b90e7852aed1f08ab5299d5d88cfa1c6ed"
-dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
- "parity-scale-codec",
- "scale-info",
- "sp-core",
- "sp-io",
- "sp-runtime",
- "sp-std",
 ]
 
 [[package]]
@@ -7761,6 +7392,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7920,21 +7560,6 @@ checksum = "8ba81f7b5faac81e528eb6158a6f3c9e0bb1008e0ffa19653bc8dea925ecb429"
 dependencies = [
  "polkavm-derive-impl",
  "syn 2.0.60",
-]
-
-[[package]]
-name = "polkavm-linker"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c7be503e60cf56c0eb785f90aaba4b583b36bff00e93997d93fef97f9553c39"
-dependencies = [
- "gimli 0.28.1",
- "hashbrown 0.14.5",
- "log",
- "object 0.32.2",
- "polkavm-common",
- "regalloc2 0.9.3",
- "rustc-demangle",
 ]
 
 [[package]]
@@ -8245,7 +7870,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19de2de2a00075bf566bee3bd4db014b11587e84184d3f7a791bc17f1a8e9e48"
 dependencies = [
  "anyhow",
- "itertools 0.12.1",
+ "itertools 0.11.0",
  "proc-macro2",
  "quote",
  "syn 2.0.60",
@@ -8634,19 +8259,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "regalloc2"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad156d539c879b7a24a363a2016d77961786e71f48f2e2fc8302a92abd2429a6"
-dependencies = [
- "hashbrown 0.13.2",
- "log",
- "rustc-hash",
- "slice-group-by",
- "smallvec",
-]
-
-[[package]]
 name = "regex"
 version = "1.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8925,7 +8537,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
- "semver 1.0.22",
+ "semver",
 ]
 
 [[package]]
@@ -9321,7 +8933,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-subspace"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=1d7ecd667be10409bfa083663b7d097848ddf08d#1d7ecd667be10409bfa083663b7d097848ddf08d"
+source = "git+https://github.com/subspace/subspace?rev=3494834414356226e10ebf7288293eda934baf6a#3494834414356226e10ebf7288293eda934baf6a"
 dependencies = [
  "async-trait",
  "futures",
@@ -9361,7 +8973,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-subspace-rpc"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=1d7ecd667be10409bfa083663b7d097848ddf08d#1d7ecd667be10409bfa083663b7d097848ddf08d"
+source = "git+https://github.com/subspace/subspace?rev=3494834414356226e10ebf7288293eda934baf6a#3494834414356226e10ebf7288293eda934baf6a"
 dependencies = [
  "async-oneshot",
  "futures",
@@ -9394,7 +9006,7 @@ dependencies = [
 [[package]]
 name = "sc-domains"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=1d7ecd667be10409bfa083663b7d097848ddf08d#1d7ecd667be10409bfa083663b7d097848ddf08d"
+source = "git+https://github.com/subspace/subspace?rev=3494834414356226e10ebf7288293eda934baf6a#3494834414356226e10ebf7288293eda934baf6a"
 dependencies = [
  "sc-client-api",
  "sc-executor",
@@ -9747,7 +9359,7 @@ dependencies = [
 [[package]]
 name = "sc-proof-of-time"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=1d7ecd667be10409bfa083663b7d097848ddf08d#1d7ecd667be10409bfa083663b7d097848ddf08d"
+source = "git+https://github.com/subspace/subspace?rev=3494834414356226e10ebf7288293eda934baf6a#3494834414356226e10ebf7288293eda934baf6a"
 dependencies = [
  "atomic",
  "core_affinity",
@@ -9976,7 +9588,7 @@ dependencies = [
 [[package]]
 name = "sc-subspace-block-relay"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=1d7ecd667be10409bfa083663b7d097848ddf08d#1d7ecd667be10409bfa083663b7d097848ddf08d"
+source = "git+https://github.com/subspace/subspace?rev=3494834414356226e10ebf7288293eda934baf6a#3494834414356226e10ebf7288293eda934baf6a"
 dependencies = [
  "async-channel 1.9.0",
  "async-trait",
@@ -9992,7 +9604,7 @@ dependencies = [
  "sp-api",
  "sp-consensus-subspace",
  "sp-runtime",
- "strum_macros 0.26.2",
+ "strum_macros",
  "substrate-prometheus-endpoint",
  "thiserror",
  "tracing",
@@ -10001,7 +9613,7 @@ dependencies = [
 [[package]]
 name = "sc-subspace-chain-specs"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=1d7ecd667be10409bfa083663b7d097848ddf08d#1d7ecd667be10409bfa083663b7d097848ddf08d"
+source = "git+https://github.com/subspace/subspace?rev=3494834414356226e10ebf7288293eda934baf6a#3494834414356226e10ebf7288293eda934baf6a"
 
 [[package]]
 name = "sc-sysinfo"
@@ -10214,12 +9826,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
-name = "scratch"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3cf7c11c38cb994f3d40e8a8cde3bbd1f72a435e4c49e85d6553d8312306152"
-
-[[package]]
 name = "sct"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10296,27 +9902,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a3186ec9e65071a2095434b1f5bb24838d4e8e130f584c790f6033c79943537"
-dependencies = [
- "semver-parser",
-]
-
-[[package]]
-name = "semver"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92d43fe69e652f3df9bdc2b85b2854a0825b86e4fb76bc44d945137d053639ca"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "semver-parser"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "send_wrapper"
@@ -10332,9 +9920,9 @@ checksum = "a3f0bf26fd526d2a95683cd0f87bf103b8539e2ca1ef48ce002d67aad59aa0b4"
 
 [[package]]
 name = "serde"
-version = "1.0.199"
+version = "1.0.200"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c9f6e76df036c77cd94996771fb40db98187f096dd0b9af39c6c6e452ba966a"
+checksum = "ddc6f9cc94d67c0e21aaf7eda3a010fd3af78ebf6e096aa6e2e13c79749cce4f"
 dependencies = [
  "serde_derive",
 ]
@@ -10359,9 +9947,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.199"
+version = "1.0.200"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11bd257a6541e141e42ca6d24ae26f7714887b47e89aa739099104c7e4d3b7fc"
+checksum = "856f046b9400cee3c8c94ed572ecdb752444c24528c035cd35882aad6f492bcb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -10376,6 +9964,15 @@ checksum = "3e17db7126d17feb94eb3fad46bf1a96b034e8aacbc2e775fe81505f8b0b2813"
 dependencies = [
  "itoa",
  "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_nanos"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a93142f0367a4cc53ae0fead1bcda39e85beccfad3dcd717656cacab94b12985"
+dependencies = [
  "serde",
 ]
 
@@ -10505,6 +10102,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "signatory"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1e303f8205714074f6068773f0e29527e0453937fe837c9717d066635b65f31"
+dependencies = [
+ "pkcs8",
+ "rand_core 0.6.4",
+ "signature",
+ "zeroize",
 ]
 
 [[package]]
@@ -10723,7 +10332,7 @@ dependencies = [
 [[package]]
 name = "sp-auto-id"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=1d7ecd667be10409bfa083663b7d097848ddf08d#1d7ecd667be10409bfa083663b7d097848ddf08d"
+source = "git+https://github.com/subspace/subspace?rev=3494834414356226e10ebf7288293eda934baf6a#3494834414356226e10ebf7288293eda934baf6a"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -10747,7 +10356,7 @@ dependencies = [
 [[package]]
 name = "sp-block-fees"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=1d7ecd667be10409bfa083663b7d097848ddf08d#1d7ecd667be10409bfa083663b7d097848ddf08d"
+source = "git+https://github.com/subspace/subspace?rev=3494834414356226e10ebf7288293eda934baf6a#3494834414356226e10ebf7288293eda934baf6a"
 dependencies = [
  "async-trait",
  "domain-runtime-primitives",
@@ -10806,7 +10415,7 @@ dependencies = [
  "sp-keystore",
  "sp-mmr-primitives",
  "sp-runtime",
- "strum 0.26.2",
+ "strum",
 ]
 
 [[package]]
@@ -10840,7 +10449,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-subspace"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=1d7ecd667be10409bfa083663b7d097848ddf08d#1d7ecd667be10409bfa083663b7d097848ddf08d"
+source = "git+https://github.com/subspace/subspace?rev=3494834414356226e10ebf7288293eda934baf6a#3494834414356226e10ebf7288293eda934baf6a"
 dependencies = [
  "async-trait",
  "log",
@@ -10976,7 +10585,7 @@ dependencies = [
 [[package]]
 name = "sp-domain-digests"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=1d7ecd667be10409bfa083663b7d097848ddf08d#1d7ecd667be10409bfa083663b7d097848ddf08d"
+source = "git+https://github.com/subspace/subspace?rev=3494834414356226e10ebf7288293eda934baf6a#3494834414356226e10ebf7288293eda934baf6a"
 dependencies = [
  "parity-scale-codec",
  "sp-runtime",
@@ -10985,7 +10594,7 @@ dependencies = [
 [[package]]
 name = "sp-domains"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=1d7ecd667be10409bfa083663b7d097848ddf08d#1d7ecd667be10409bfa083663b7d097848ddf08d"
+source = "git+https://github.com/subspace/subspace?rev=3494834414356226e10ebf7288293eda934baf6a#3494834414356226e10ebf7288293eda934baf6a"
 dependencies = [
  "blake2 0.10.6",
  "domain-runtime-primitives",
@@ -11017,7 +10626,7 @@ dependencies = [
 [[package]]
 name = "sp-domains-fraud-proof"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=1d7ecd667be10409bfa083663b7d097848ddf08d#1d7ecd667be10409bfa083663b7d097848ddf08d"
+source = "git+https://github.com/subspace/subspace?rev=3494834414356226e10ebf7288293eda934baf6a#3494834414356226e10ebf7288293eda934baf6a"
 dependencies = [
  "domain-block-preprocessor",
  "domain-runtime-primitives",
@@ -11050,7 +10659,7 @@ dependencies = [
 [[package]]
 name = "sp-executive"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=1d7ecd667be10409bfa083663b7d097848ddf08d#1d7ecd667be10409bfa083663b7d097848ddf08d"
+source = "git+https://github.com/subspace/subspace?rev=3494834414356226e10ebf7288293eda934baf6a#3494834414356226e10ebf7288293eda934baf6a"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -11139,7 +10748,7 @@ dependencies = [
 [[package]]
 name = "sp-messenger"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=1d7ecd667be10409bfa083663b7d097848ddf08d#1d7ecd667be10409bfa083663b7d097848ddf08d"
+source = "git+https://github.com/subspace/subspace?rev=3494834414356226e10ebf7288293eda934baf6a#3494834414356226e10ebf7288293eda934baf6a"
 dependencies = [
  "async-trait",
  "frame-support",
@@ -11161,7 +10770,7 @@ dependencies = [
 [[package]]
 name = "sp-messenger-host-functions"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=1d7ecd667be10409bfa083663b7d097848ddf08d#1d7ecd667be10409bfa083663b7d097848ddf08d"
+source = "git+https://github.com/subspace/subspace?rev=3494834414356226e10ebf7288293eda934baf6a#3494834414356226e10ebf7288293eda934baf6a"
 dependencies = [
  "domain-block-preprocessor",
  "parity-scale-codec",
@@ -11218,7 +10827,7 @@ dependencies = [
 [[package]]
 name = "sp-objects"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=1d7ecd667be10409bfa083663b7d097848ddf08d#1d7ecd667be10409bfa083663b7d097848ddf08d"
+source = "git+https://github.com/subspace/subspace?rev=3494834414356226e10ebf7288293eda934baf6a#3494834414356226e10ebf7288293eda934baf6a"
 dependencies = [
  "sp-api",
  "subspace-core-primitives",
@@ -11402,7 +11011,7 @@ dependencies = [
 [[package]]
 name = "sp-subspace-mmr"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=1d7ecd667be10409bfa083663b7d097848ddf08d#1d7ecd667be10409bfa083663b7d097848ddf08d"
+source = "git+https://github.com/subspace/subspace?rev=3494834414356226e10ebf7288293eda934baf6a#3494834414356226e10ebf7288293eda934baf6a"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -11583,7 +11192,7 @@ dependencies = [
  "sc-service",
  "sc-storage-monitor",
  "sc-subspace-chain-specs",
- "semver 1.0.22",
+ "semver",
  "serde",
  "serde_json",
  "simple_moving_average",
@@ -11593,12 +11202,12 @@ dependencies = [
  "sp-runtime",
  "subspace-core-primitives",
  "subspace-erasure-coding",
+ "subspace-fake-runtime-api",
  "subspace-farmer",
  "subspace-farmer-components",
  "subspace-networking",
  "subspace-proof-of-space",
  "subspace-rpc-primitives",
- "subspace-runtime",
  "subspace-runtime-primitives",
  "subspace-service",
  "supports-color",
@@ -11713,30 +11322,11 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
-version = "0.24.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
-
-[[package]]
-name = "strum"
 version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d8cec3501a5194c432b2b7976db6b7d10ec95c253208b45f83f7136aa985e29"
 dependencies = [
- "strum_macros 0.26.2",
-]
-
-[[package]]
-name = "strum_macros"
-version = "0.24.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
-dependencies = [
- "heck 0.4.1",
- "proc-macro2",
- "quote",
- "rustversion",
- "syn 1.0.109",
+ "strum_macros",
 ]
 
 [[package]]
@@ -11755,7 +11345,7 @@ dependencies = [
 [[package]]
 name = "subspace-archiving"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=1d7ecd667be10409bfa083663b7d097848ddf08d#1d7ecd667be10409bfa083663b7d097848ddf08d"
+source = "git+https://github.com/subspace/subspace?rev=3494834414356226e10ebf7288293eda934baf6a#3494834414356226e10ebf7288293eda934baf6a"
 dependencies = [
  "parity-scale-codec",
  "rayon",
@@ -11768,7 +11358,7 @@ dependencies = [
 [[package]]
 name = "subspace-core-primitives"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=1d7ecd667be10409bfa083663b7d097848ddf08d#1d7ecd667be10409bfa083663b7d097848ddf08d"
+source = "git+https://github.com/subspace/subspace?rev=3494834414356226e10ebf7288293eda934baf6a#3494834414356226e10ebf7288293eda934baf6a"
 dependencies = [
  "blake3",
  "derive_more",
@@ -11791,7 +11381,7 @@ dependencies = [
 [[package]]
 name = "subspace-erasure-coding"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=1d7ecd667be10409bfa083663b7d097848ddf08d#1d7ecd667be10409bfa083663b7d097848ddf08d"
+source = "git+https://github.com/subspace/subspace?rev=3494834414356226e10ebf7288293eda934baf6a#3494834414356226e10ebf7288293eda934baf6a"
 dependencies = [
  "kzg",
  "rust-kzg-blst",
@@ -11799,12 +11389,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "subspace-fake-runtime-api"
+version = "0.1.0"
+source = "git+https://github.com/subspace/subspace?rev=3494834414356226e10ebf7288293eda934baf6a#3494834414356226e10ebf7288293eda934baf6a"
+dependencies = [
+ "domain-runtime-primitives",
+ "frame-support",
+ "frame-system-rpc-runtime-api",
+ "pallet-mmr",
+ "pallet-transaction-payment",
+ "pallet-transaction-payment-rpc-runtime-api",
+ "sp-api",
+ "sp-block-builder",
+ "sp-blockchain",
+ "sp-consensus-subspace",
+ "sp-core",
+ "sp-domains",
+ "sp-domains-fraud-proof",
+ "sp-genesis-builder",
+ "sp-inherents",
+ "sp-messenger",
+ "sp-objects",
+ "sp-offchain",
+ "sp-runtime",
+ "sp-session",
+ "sp-transaction-pool",
+ "sp-version",
+ "subspace-core-primitives",
+ "subspace-runtime-primitives",
+]
+
+[[package]]
 name = "subspace-farmer"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=1d7ecd667be10409bfa083663b7d097848ddf08d#1d7ecd667be10409bfa083663b7d097848ddf08d"
+source = "git+https://github.com/subspace/subspace?rev=3494834414356226e10ebf7288293eda934baf6a#3494834414356226e10ebf7288293eda934baf6a"
 dependencies = [
  "anyhow",
  "async-lock",
+ "async-nats",
  "async-trait",
  "backoff",
  "base58",
@@ -11827,6 +11449,7 @@ dependencies = [
  "num_cpus",
  "parity-scale-codec",
  "parking_lot 0.12.2",
+ "pin-project",
  "prometheus-client 0.22.2",
  "rand",
  "rayon",
@@ -11858,7 +11481,7 @@ dependencies = [
 [[package]]
 name = "subspace-farmer-components"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=1d7ecd667be10409bfa083663b7d097848ddf08d#1d7ecd667be10409bfa083663b7d097848ddf08d"
+source = "git+https://github.com/subspace/subspace?rev=3494834414356226e10ebf7288293eda934baf6a#3494834414356226e10ebf7288293eda934baf6a"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -11889,7 +11512,7 @@ dependencies = [
 [[package]]
 name = "subspace-metrics"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=1d7ecd667be10409bfa083663b7d097848ddf08d#1d7ecd667be10409bfa083663b7d097848ddf08d"
+source = "git+https://github.com/subspace/subspace?rev=3494834414356226e10ebf7288293eda934baf6a#3494834414356226e10ebf7288293eda934baf6a"
 dependencies = [
  "actix-web",
  "prometheus",
@@ -11900,7 +11523,7 @@ dependencies = [
 [[package]]
 name = "subspace-networking"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=1d7ecd667be10409bfa083663b7d097848ddf08d#1d7ecd667be10409bfa083663b7d097848ddf08d"
+source = "git+https://github.com/subspace/subspace?rev=3494834414356226e10ebf7288293eda934baf6a#3494834414356226e10ebf7288293eda934baf6a"
 dependencies = [
  "async-mutex",
  "async-trait",
@@ -11938,7 +11561,7 @@ dependencies = [
 [[package]]
 name = "subspace-proof-of-space"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=1d7ecd667be10409bfa083663b7d097848ddf08d#1d7ecd667be10409bfa083663b7d097848ddf08d"
+source = "git+https://github.com/subspace/subspace?rev=3494834414356226e10ebf7288293eda934baf6a#3494834414356226e10ebf7288293eda934baf6a"
 dependencies = [
  "chacha20",
  "derive_more",
@@ -11951,7 +11574,7 @@ dependencies = [
 [[package]]
 name = "subspace-proof-of-time"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=1d7ecd667be10409bfa083663b7d097848ddf08d#1d7ecd667be10409bfa083663b7d097848ddf08d"
+source = "git+https://github.com/subspace/subspace?rev=3494834414356226e10ebf7288293eda934baf6a#3494834414356226e10ebf7288293eda934baf6a"
 dependencies = [
  "aes",
  "subspace-core-primitives",
@@ -11961,7 +11584,7 @@ dependencies = [
 [[package]]
 name = "subspace-rpc-primitives"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=1d7ecd667be10409bfa083663b7d097848ddf08d#1d7ecd667be10409bfa083663b7d097848ddf08d"
+source = "git+https://github.com/subspace/subspace?rev=3494834414356226e10ebf7288293eda934baf6a#3494834414356226e10ebf7288293eda934baf6a"
 dependencies = [
  "hex",
  "parity-scale-codec",
@@ -11972,66 +11595,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "subspace-runtime"
-version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=1d7ecd667be10409bfa083663b7d097848ddf08d#1d7ecd667be10409bfa083663b7d097848ddf08d"
-dependencies = [
- "domain-runtime-primitives",
- "frame-benchmarking",
- "frame-executive",
- "frame-support",
- "frame-system",
- "frame-system-benchmarking",
- "frame-system-rpc-runtime-api",
- "orml-vesting",
- "pallet-balances",
- "pallet-domains",
- "pallet-messenger",
- "pallet-mmr",
- "pallet-offences-subspace",
- "pallet-rewards",
- "pallet-runtime-configs",
- "pallet-subspace",
- "pallet-subspace-mmr",
- "pallet-sudo",
- "pallet-timestamp",
- "pallet-transaction-fees",
- "pallet-transaction-payment",
- "pallet-transaction-payment-rpc-runtime-api",
- "pallet-transporter",
- "pallet-utility",
- "parity-scale-codec",
- "scale-info",
- "sp-api",
- "sp-block-builder",
- "sp-consensus-slots",
- "sp-consensus-subspace",
- "sp-core",
- "sp-domains",
- "sp-domains-fraud-proof",
- "sp-genesis-builder",
- "sp-inherents",
- "sp-messenger",
- "sp-messenger-host-functions",
- "sp-mmr-primitives",
- "sp-objects",
- "sp-offchain",
- "sp-runtime",
- "sp-session",
- "sp-std",
- "sp-subspace-mmr",
- "sp-transaction-pool",
- "sp-version",
- "static_assertions",
- "subspace-core-primitives",
- "subspace-runtime-primitives",
- "substrate-wasm-builder",
-]
-
-[[package]]
 name = "subspace-runtime-primitives"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=1d7ecd667be10409bfa083663b7d097848ddf08d#1d7ecd667be10409bfa083663b7d097848ddf08d"
+source = "git+https://github.com/subspace/subspace?rev=3494834414356226e10ebf7288293eda934baf6a#3494834414356226e10ebf7288293eda934baf6a"
 dependencies = [
  "pallet-transaction-payment",
  "sp-core",
@@ -12042,7 +11608,7 @@ dependencies = [
 [[package]]
 name = "subspace-service"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=1d7ecd667be10409bfa083663b7d097848ddf08d#1d7ecd667be10409bfa083663b7d097848ddf08d"
+source = "git+https://github.com/subspace/subspace?rev=3494834414356226e10ebf7288293eda934baf6a#3494834414356226e10ebf7288293eda934baf6a"
 dependencies = [
  "async-trait",
  "cross-domain-message-gossip",
@@ -12119,7 +11685,7 @@ dependencies = [
 [[package]]
 name = "subspace-verification"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=1d7ecd667be10409bfa083663b7d097848ddf08d#1d7ecd667be10409bfa083663b7d097848ddf08d"
+source = "git+https://github.com/subspace/subspace?rev=3494834414356226e10ebf7288293eda934baf6a#3494834414356226e10ebf7288293eda934baf6a"
 dependencies = [
  "parity-scale-codec",
  "schnorrkel",
@@ -12183,25 +11749,6 @@ dependencies = [
  "prometheus",
  "thiserror",
  "tokio",
-]
-
-[[package]]
-name = "substrate-wasm-builder"
-version = "17.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=44d742b90e7852aed1f08ab5299d5d88cfa1c6ed#44d742b90e7852aed1f08ab5299d5d88cfa1c6ed"
-dependencies = [
- "build-helper",
- "cargo_metadata",
- "console",
- "filetime",
- "parity-wasm",
- "polkavm-linker",
- "sp-maybe-compressed-blob",
- "strum 0.26.2",
- "tempfile",
- "toml 0.8.12",
- "walkdir",
- "wasm-opt",
 ]
 
 [[package]]
@@ -12884,6 +12431,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "tryhard"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c9f0a709784e86923586cff0d872dba54cd2d2e116b3bc57587d15737cfce9d"
+dependencies = [
+ "futures",
+ "pin-project-lite 0.2.14",
+ "tokio",
+]
+
+[[package]]
 name = "tt-call"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12962,12 +12520,6 @@ checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
 dependencies = [
  "tinyvec",
 ]
-
-[[package]]
-name = "unicode-width"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68f5e5f3158ecfd4b8ff6fe086db7c8467a2dfdac97fe420f2b7c4aa97af66d6"
 
 [[package]]
 name = "unicode-xid"
@@ -13206,46 +12758,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a47ecb37b9734d1085eaa5ae1a81e60801fd8c28d4cabdd8aedb982021918bc"
 dependencies = [
  "parity-wasm",
-]
-
-[[package]]
-name = "wasm-opt"
-version = "0.116.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fd87a4c135535ffed86123b6fb0f0a5a0bc89e50416c942c5f0662c645f679c"
-dependencies = [
- "anyhow",
- "libc",
- "strum 0.24.1",
- "strum_macros 0.24.3",
- "tempfile",
- "thiserror",
- "wasm-opt-cxx-sys",
- "wasm-opt-sys",
-]
-
-[[package]]
-name = "wasm-opt-cxx-sys"
-version = "0.116.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c57b28207aa724318fcec6575fe74803c23f6f266fce10cbc9f3f116762f12e"
-dependencies = [
- "anyhow",
- "cxx",
- "cxx-build",
- "wasm-opt-sys",
-]
-
-[[package]]
-name = "wasm-opt-sys"
-version = "0.116.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a1cce564dc768dacbdb718fc29df2dba80bd21cb47d8f77ae7e3d95ceb98cbe"
-dependencies = [
- "anyhow",
- "cc",
- "cxx",
- "cxx-build",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,25 +75,25 @@ sc-informant = { git = "https://github.com/subspace/polkadot-sdk", rev = "44d742
 sc-network = { git = "https://github.com/subspace/polkadot-sdk", rev = "44d742b90e7852aed1f08ab5299d5d88cfa1c6ed", default-features = false }
 sc-service = { git = "https://github.com/subspace/polkadot-sdk", rev = "44d742b90e7852aed1f08ab5299d5d88cfa1c6ed", default-features = false }
 sc-storage-monitor = { git = "https://github.com/subspace/polkadot-sdk", rev = "44d742b90e7852aed1f08ab5299d5d88cfa1c6ed", default-features = false }
-sc-subspace-chain-specs = { git = "https://github.com/subspace/subspace", rev = "1d7ecd667be10409bfa083663b7d097848ddf08d" }
+sc-subspace-chain-specs = { git = "https://github.com/subspace/subspace", rev = "3494834414356226e10ebf7288293eda934baf6a" }
 semver = "1.0.22"
 serde = { version = "1.0.199", features = ["derive"] }
 serde_json = "1.0.116"
 simple_moving_average = "1.0.2"
 sp-core = { git = "https://github.com/subspace/polkadot-sdk", rev = "44d742b90e7852aed1f08ab5299d5d88cfa1c6ed", default-features = false }
-sp-consensus-subspace = { git = "https://github.com/subspace/subspace", rev = "1d7ecd667be10409bfa083663b7d097848ddf08d" }
-sp-domains-fraud-proof = { git = "https://github.com/subspace/subspace", rev = "1d7ecd667be10409bfa083663b7d097848ddf08d" }
+sp-consensus-subspace = { git = "https://github.com/subspace/subspace", rev = "3494834414356226e10ebf7288293eda934baf6a" }
+sp-domains-fraud-proof = { git = "https://github.com/subspace/subspace", rev = "3494834414356226e10ebf7288293eda934baf6a" }
 sp-runtime = { git = "https://github.com/subspace/polkadot-sdk", rev = "44d742b90e7852aed1f08ab5299d5d88cfa1c6ed", default-features = false }
-subspace-core-primitives = { git = "https://github.com/subspace/subspace", rev = "1d7ecd667be10409bfa083663b7d097848ddf08d" }
-subspace-erasure-coding = { git = "https://github.com/subspace/subspace", rev = "1d7ecd667be10409bfa083663b7d097848ddf08d" }
-subspace-farmer = { git = "https://github.com/subspace/subspace", rev = "1d7ecd667be10409bfa083663b7d097848ddf08d", default-features = false }
-subspace-farmer-components = { git = "https://github.com/subspace/subspace", rev = "1d7ecd667be10409bfa083663b7d097848ddf08d" }
-subspace-networking = { git = "https://github.com/subspace/subspace", rev = "1d7ecd667be10409bfa083663b7d097848ddf08d" }
-subspace-proof-of-space = { git = "https://github.com/subspace/subspace", rev = "1d7ecd667be10409bfa083663b7d097848ddf08d" }
-subspace-rpc-primitives = { git = "https://github.com/subspace/subspace", rev = "1d7ecd667be10409bfa083663b7d097848ddf08d" }
-subspace-runtime = { git = "https://github.com/subspace/subspace", rev = "1d7ecd667be10409bfa083663b7d097848ddf08d" }
-subspace-runtime-primitives = { git = "https://github.com/subspace/subspace", rev = "1d7ecd667be10409bfa083663b7d097848ddf08d" }
-subspace-service = { git = "https://github.com/subspace/subspace", rev = "1d7ecd667be10409bfa083663b7d097848ddf08d" }
+subspace-core-primitives = { git = "https://github.com/subspace/subspace", rev = "3494834414356226e10ebf7288293eda934baf6a" }
+subspace-erasure-coding = { git = "https://github.com/subspace/subspace", rev = "3494834414356226e10ebf7288293eda934baf6a" }
+subspace-fake-runtime-api = { git = "https://github.com/subspace/subspace", rev = "3494834414356226e10ebf7288293eda934baf6a" }
+subspace-farmer = { git = "https://github.com/subspace/subspace", rev = "3494834414356226e10ebf7288293eda934baf6a", default-features = false }
+subspace-farmer-components = { git = "https://github.com/subspace/subspace", rev = "3494834414356226e10ebf7288293eda934baf6a" }
+subspace-networking = { git = "https://github.com/subspace/subspace", rev = "3494834414356226e10ebf7288293eda934baf6a" }
+subspace-proof-of-space = { git = "https://github.com/subspace/subspace", rev = "3494834414356226e10ebf7288293eda934baf6a" }
+subspace-rpc-primitives = { git = "https://github.com/subspace/subspace", rev = "3494834414356226e10ebf7288293eda934baf6a" }
+subspace-runtime-primitives = { git = "https://github.com/subspace/subspace", rev = "3494834414356226e10ebf7288293eda934baf6a" }
+subspace-service = { git = "https://github.com/subspace/subspace", rev = "3494834414356226e10ebf7288293eda934baf6a" }
 supports-color = "3.0.0"
 thiserror = "1.0.59"
 thread-priority = "1.1.0"


### PR DESCRIPTION
companion PR https://github.com/subspace/subspace/pull/2735

Before:
```bash
Building [===========>            ] 708/1336:
```
Now:

```bash
 Building [=====================> ] 1257/1268
```