### PR TITLE
Force old GL renderer on old CPUs (and likely GPUs by extension) on Windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11151,7 +11151,7 @@ dependencies = [
 
 [[package]]
 name = "space-acres"
-version = "0.1.18"
+version = "0.1.19"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "space-acres"
 description = "Space Acres is an opinionated GUI application for farming on Subspace Network"
 license = "0BSD"
-version = "0.1.18"
+version = "0.1.19"
 authors = ["Nazar Mokrynskyi <nazar@mokrynskyi.com>"]
 repository = "https://github.com/subspace/space-acres"
 edition = "2021"


### PR DESCRIPTION
Upstream regression affecting old Intel iGPUs (and maybe some others as well, but hard to tell)