### PR TITLE
Fix genesis hash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11189,7 +11189,7 @@ dependencies = [
 
 [[package]]
 name = "space-acres"
-version = "0.1.20"
+version = "0.1.21"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "space-acres"
 description = "Space Acres is an opinionated GUI application for farming on Subspace Network"
 license = "0BSD"
-version = "0.1.20"
+version = "0.1.21"
 authors = ["Nazar Mokrynskyi <nazar@mokrynskyi.com>"]
 repository = "https://github.com/subspace/space-acres"
 edition = "2021"

--- a/src/backend/farmer/direct_node_client.rs
+++ b/src/backend/farmer/direct_node_client.rs
@@ -138,7 +138,7 @@ where
     pub fn new(config: NodeClientConfig<Client>) -> Result<Self, ApiError> {
         let info = config.client.info();
         let best_hash = info.best_hash;
-        let genesis_hash = BlockHash::try_from(best_hash.as_ref().to_vec())
+        let genesis_hash = BlockHash::try_from(info.genesis_hash.as_ref())
             .expect("Genesis hash must always be convertable into BlockHash; qed");
         let runtime_api = config.client.runtime_api();
         let chain_constants = runtime_api.chain_constants(best_hash)?;


### PR DESCRIPTION
Regression from https://github.com/subspace/space-acres/pull/192 that prevents farms from starting

@dastansam not sure why you changed it. Genesis hash and best hash are different things and it was correct in RPC implementation in monorepo.