### PR TITLE
Change feedback TypeForm to LinkTree

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -256,7 +256,7 @@ impl AsyncComponent for App {
 
                                     gtk::Button {
                                         connect_clicked => AppInput::OpenFeedbackLink,
-                                        set_label: "Leave Feedback / Report a Bug",
+                                        set_label: "Share feedback",
                                     },
 
                                     gtk::Button {

--- a/src/main.rs
+++ b/src/main.rs
@@ -256,7 +256,7 @@ impl AsyncComponent for App {
 
                                     gtk::Button {
                                         connect_clicked => AppInput::OpenFeedbackLink,
-                                        set_label: "Feedback",
+                                        set_label: "Leave Feedback / Report a Bug",
                                     },
 
                                     gtk::Button {
@@ -614,7 +614,7 @@ impl AsyncComponent for App {
             }
             AppInput::OpenFeedbackLink => {
                 self.menu_popover.hide();
-                gtk::show_uri(Some(root), "https://subspace.typeform.com/to/tRe4Z0uI", 0);
+                gtk::show_uri(Some(root), "https://linktr.ee/subspace_network", 0);
             }
             AppInput::ShowAboutDialog => {
                 self.menu_popover.hide();


### PR DESCRIPTION
The feedback TypeForm was swapped to a Linktree page, with more options for users to raise an issue, search for help or leave feedback. 

I changed the label on the button, can't say if it's going to be too long for the UI.