### PR TITLE
Predict when the next reward will be farmed

### DIFF
--- a/src/backend.rs
+++ b/src/backend.rs
@@ -186,7 +186,6 @@ enum LoadedConsensusChainNode {
     Incompatible { compatible_chain: String },
 }
 
-#[allow(dead_code)]
 #[derive(Debug, Clone)]
 pub enum NodeNotification {
     SyncStateUpdate(SyncState),

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -529,10 +529,11 @@ async fn run(
             }
         })
     });
+    let (current_solution_range, max_pieces_in_sector) =
+        consensus_node.total_space_pledged_chain_constants()?;
     let _on_imported_block_handler_id = consensus_node.on_block_imported({
         let notifications_sender = notifications_sender.clone();
         // let reward_address_storage_key = account_storage_key(&config.reward_address);
-        let (current_solution_range, max_pieces_in_sector) = consensus_node.tsp_metrics()?;
 
         Arc::new(move |&imported_block| {
             let notification = NodeNotification::BlockImported {

--- a/src/backend/farmer.rs
+++ b/src/backend/farmer.rs
@@ -696,7 +696,6 @@ where
 
 /// Calculate the ETA for reward payment.
 /// The farmer can expect reward in secs/mins/hrs/days/weeks time.
-#[allow(dead_code)]
 pub(crate) fn calculate_expected_reward_duration_from_now(
     total_space_pledged: u128,
     space_pledged: u128,

--- a/src/backend/node.rs
+++ b/src/backend/node.rs
@@ -122,8 +122,8 @@ struct Handlers {
     block_imported: Handler<BlockImported>,
 }
 
-pub(crate) struct ConsensusNode {
-    pub(crate) full_node: NewFull<FullClient<RuntimeApi>>,
+pub(super) struct ConsensusNode {
+    pub(super) full_node: NewFull<FullClient<RuntimeApi>>,
     pause_sync: Arc<AtomicBool>,
     chain_info: ChainInfo,
     handlers: Handlers,
@@ -242,7 +242,7 @@ impl ConsensusNode {
     }
 
     /// Returns current solution range & max. pieces in a sector
-    pub(super) fn tsp_metrics(&self) -> anyhow::Result<(u64, u16)> {
+    pub(super) fn total_space_pledged_chain_constants(&self) -> anyhow::Result<(u64, u16)> {
         let runtime_api = self.full_node.client.runtime_api();
         let block_hash = self.full_node.client.info().best_hash;
         let current_solution_range = runtime_api.solution_ranges(block_hash)?.current;

--- a/src/backend/utils.rs
+++ b/src/backend/utils.rs
@@ -3,3 +3,7 @@ use std::sync::Arc;
 
 pub(super) type HandlerFn<A> = Arc<dyn Fn(&A) + Send + Sync + 'static>;
 pub(super) type Handler<A> = Bag<HandlerFn<A>, A>;
+
+// TODO: Expose this via chain constants.
+// https://github.com/subspace/subspace/blob/e1322171af8eb2440ae8ab9e28c7e22ef42f6f6c/crates/subspace-runtime/src/lib.rs#L186
+pub(super) const EXPECTED_VOTES_PER_BLOCK: u32 = 9;

--- a/src/frontend.rs
+++ b/src/frontend.rs
@@ -1,6 +1,6 @@
+pub mod circular_progress_bar;
 pub mod configuration;
 pub mod loading;
 pub mod new_version;
-pub mod progress_bar;
 pub mod running;
 pub mod utils;

--- a/src/frontend.rs
+++ b/src/frontend.rs
@@ -1,4 +1,6 @@
 pub mod configuration;
 pub mod loading;
 pub mod new_version;
+pub mod progress_bar;
 pub mod running;
+pub mod utils;

--- a/src/frontend/circular_progress_bar.rs
+++ b/src/frontend/circular_progress_bar.rs
@@ -125,11 +125,3 @@ impl Component for CircularProgressBar {
         }
     }
 }
-
-/// Calculate the decrease value and interval for the progress updates
-pub(crate) fn calculate_progress_params(eta_in_secs: u64) -> (f64, u64) {
-    let interval = 1; // Default interval of 1 second (1000 milliseconds)
-    let steps = eta_in_secs / interval;
-    let decrease_value = 1.0 / steps as f64;
-    (decrease_value, interval)
-}

--- a/src/frontend/progress_bar.rs
+++ b/src/frontend/progress_bar.rs
@@ -1,0 +1,125 @@
+use gtk::prelude::*;
+use relm4::prelude::*;
+use std::cell::RefCell;
+use std::f64::consts::PI;
+use std::rc::Rc;
+
+pub(crate) const DEFAULT_TOOLTIP_ETA_PROGRESS_BAR: &str = "ETA for next reward payment";
+
+#[derive(Debug, Clone)]
+pub struct CircularProgressBar {
+    progress: Rc<RefCell<f64>>,
+    tooltip_text: String,
+    diameter: f64,
+}
+
+#[derive(Debug)]
+pub enum ProgressBarInput {
+    SetProgress(f64),
+    SetTooltip(String),
+}
+
+#[relm4::component(pub)]
+impl Component for CircularProgressBar {
+    type Init = f64; // Diameter of the progress bar
+    type Input = ProgressBarInput;
+    type Output = ();
+    type CommandOutput = ();
+
+    view! {
+        #[root]
+        gtk::DrawingArea {
+            set_content_width: (model.diameter + 1.0) as i32,
+            set_content_height: (model.diameter + 1.0) as i32,
+            set_margin_top: 10,
+            set_margin_bottom: 10,
+            set_margin_start: 10,
+            set_margin_end: 10,
+            set_visible: true,
+            set_draw_func: {
+                let progress_clone = model.progress.clone();
+                let diameter = model.diameter;
+                move |_, cr, width, height| {
+                    let percentage = *progress_clone.borrow();
+
+                    // Center coordinates
+                    let center_x = width as f64 / 2.0;
+                    let center_y = height as f64 / 2.0;
+
+                    // Draw the background circle with respective color in dark/light themes
+                    if matches!(dark_light::detect(), dark_light::Mode::Dark) {
+                        // Grey for dark theme
+                        cr.set_source_rgb(0.2078431373, 0.2078431373, 0.2078431373);
+                    } else {
+                        // White smoke for light theme
+                        cr.set_source_rgb(0.965, 0.961, 0.957);
+                    }
+                    cr.arc(center_x, center_y, diameter / 2.0, 0.0, 2.0 * PI);
+                    // let _ = cr.fill();       // NOTE: Fill w/o border color
+                    let _ = cr.fill_preserve(); // Preserve the path for stroking
+                    cr.set_source_rgb(0.0, 0.0, 0.0); // Black border color for both the themes.
+                    cr.set_line_width(0.5); // Set the border width
+                    let _ = cr.stroke(); // Draw the circle border
+
+                    // Draw the sweeping with respective color in dark/light themes
+                    if matches!(dark_light::detect(), dark_light::Mode::Dark) {
+                        // White smoke for dark theme
+                        cr.set_source_rgb(0.965, 0.961, 0.957);
+                    } else {
+                        // Grey for light theme
+                        cr.set_source_rgb(0.2078431373, 0.2078431373, 0.2078431373);
+                    }
+                    cr.arc(
+                        center_x,
+                        center_y,
+                        diameter / 2.0,
+                        -PI / 2.0,
+                        -PI / 2.0 + 2.0 * PI * percentage,
+                    );
+                    cr.line_to(center_x, center_y);
+                    let _ = cr.fill();
+                }
+            },
+            set_tooltip_text: Some(&model.tooltip_text),
+        }
+    }
+
+    fn init(
+        diameter: Self::Init,
+        _root: Self::Root,
+        _sender: ComponentSender<Self>,
+    ) -> ComponentParts<Self> {
+        let progress = Rc::new(RefCell::new(0.0));
+        let tooltip_text = DEFAULT_TOOLTIP_ETA_PROGRESS_BAR.to_string();
+
+        let model = Self {
+            progress,
+            tooltip_text,
+            diameter,
+        };
+
+        let widgets = view_output!();
+        ComponentParts { model, widgets }
+    }
+
+    fn update(&mut self, input: Self::Input, _sender: ComponentSender<Self>, root: &Self::Root) {
+        match input {
+            ProgressBarInput::SetProgress(p) => {
+                *self.progress.borrow_mut() = p;
+                root.queue_draw();
+            }
+            ProgressBarInput::SetTooltip(text) => {
+                self.tooltip_text = text;
+                root.set_tooltip_text(Some(&self.tooltip_text));
+            }
+        }
+    }
+}
+
+/// Calculate the decrease value and interval for the progress updates
+pub(crate) fn calculate_progress_params(eta: u64) -> (f64, u64) {
+    let interval = 1000; // Default interval of 1 second (1000 milliseconds)
+    let steps = eta / interval;
+    let decrease_value = 1.0 / steps as f64;
+    (decrease_value, interval)
+}

--- a/src/frontend/running.rs
+++ b/src/frontend/running.rs
@@ -11,6 +11,7 @@ use gtk::prelude::*;
 use relm4::factory::FactoryHashMap;
 use relm4::prelude::*;
 use relm4_icons::icon_name;
+use sp_consensus_subspace::ChainConstants;
 use subspace_core_primitives::BlockNumber;
 use subspace_runtime_primitives::{Balance, SSC};
 use tracing::debug;
@@ -20,6 +21,7 @@ pub struct RunningInit {
     pub plotting_paused: bool,
 }
 
+#[allow(dead_code)]
 #[derive(Debug)]
 pub enum RunningInput {
     Initialize {
@@ -28,6 +30,7 @@ pub enum RunningInput {
         initial_farm_states: Vec<InitialFarmState>,
         raw_config: RawConfig,
         chain_info: ChainInfo,
+        chain_constants: ChainConstants,
     },
     NodeNotification(NodeNotification),
     FarmerNotification(FarmerNotification<FarmIndex>),
@@ -221,6 +224,7 @@ impl RunningView {
                 initial_farm_states,
                 raw_config,
                 chain_info,
+                chain_constants: _,
             } => {
                 for (farm_index, (initial_farm_state, farm)) in initial_farm_states
                     .iter()
@@ -277,7 +281,11 @@ impl RunningView {
                         }
                         self.node_synced = new_synced;
                     }
-                    NodeNotification::BlockImported(imported_block) => {
+                    NodeNotification::BlockImported {
+                        imported_block,
+                        current_solution_range: _,
+                        max_pieces_in_sector: _,
+                    } => {
                         if !self.node_synced {
                             // Do not count balance increase during sync as increase related to
                             // farming, but preserve accumulated diff

--- a/src/frontend/running.rs
+++ b/src/frontend/running.rs
@@ -24,7 +24,7 @@ use subspace_core_primitives::BlockNumber;
 use subspace_runtime_primitives::{Balance, SSC};
 use tracing::debug;
 
-const DEFAULT_TOOLTIP_ETA_PROGRESS_BAR: &str = "ETA for next reward payment";
+const DEFAULT_TOOLTIP_ETA_PROGRESS_BAR: &str = "ETA for next reward\nWaiting for node to sync..⏳";
 
 #[derive(Debug)]
 pub struct RunningInit {

--- a/src/frontend/running/node.rs
+++ b/src/frontend/running/node.rs
@@ -291,7 +291,7 @@ impl NodeView {
                     }
                     self.sync_state = new_sync_state;
                 }
-                NodeNotification::BlockImported(imported_block) => {
+                NodeNotification::BlockImported { imported_block, .. } => {
                     self.best_block_number = imported_block.number;
                     // Ensure target is never below current block
                     if let SyncState::Syncing { target, .. } = &mut self.sync_state {

--- a/src/frontend/running/node.rs
+++ b/src/frontend/running/node.rs
@@ -291,7 +291,7 @@ impl NodeView {
                     }
                     self.sync_state = new_sync_state;
                 }
-                NodeNotification::BlockImported { imported_block, .. } => {
+                NodeNotification::BlockImported(imported_block) => {
                     self.best_block_number = imported_block.number;
                     // Ensure target is never below current block
                     if let SyncState::Syncing { target, .. } = &mut self.sync_state {
@@ -305,6 +305,7 @@ impl NodeView {
                             .add_sample(last_block_import_time.elapsed());
                     }
                 }
+                _ => {}
             },
             NodeInput::OpenNodeFolder => {
                 let node_path = self.node_path.lock().clone();

--- a/src/frontend/utils.rs
+++ b/src/frontend/utils.rs
@@ -1,58 +1,38 @@
-const WEEK: u64 = 604800000;
-const DAY: u64 = 86400000;
-const HOUR: u64 = 3600000;
-const MINUTE: u64 = 60000;
-const SECOND: u64 = 1000;
+const SECOND: u64 = 1;
+const MINUTE: u64 = 60 * SECOND;
+const HOUR: u64 = 60 * MINUTE;
+const DAY: u64 = 24 * HOUR;
+const WEEK: u64 = 7 * DAY;
 
-/// Format ETA from milliseconds to a human-readable string with up to two time units
-pub(crate) fn format_eta(eta_millis: u64) -> String {
-    if eta_millis == 0 || eta_millis < SECOND {
-        return "0 secs".to_string();
+/// Format ETA from milliseconds to an approximate time duration
+pub(crate) fn format_eta(eta_secs: u64) -> String {
+    match eta_secs {
+        0 => "any time now".to_string(),
+        _ if eta_secs < SECOND => "any time now".to_string(),
+        _ if eta_secs >= WEEK => format!("{} weeks", eta_secs / WEEK),
+        _ if eta_secs >= DAY => format!("{} days", eta_secs / DAY),
+        _ if eta_secs >= HOUR => format!("{} hours", eta_secs / HOUR),
+        _ if eta_secs >= MINUTE => format!("{} mins", eta_secs / MINUTE),
+        _ => format!("{} secs", eta_secs / SECOND),
     }
-
-    let weeks = eta_millis / WEEK;
-    let days = (eta_millis % WEEK) / DAY;
-    let hours = (eta_millis % DAY) / HOUR;
-    let minutes = (eta_millis % HOUR) / MINUTE;
-    let seconds = (eta_millis % MINUTE) / SECOND;
-
-    let mut parts = Vec::new();
-
-    if weeks > 0 {
-        parts.push(format!("{} weeks", weeks));
-    }
-    if days > 0 {
-        parts.push(format!("{} days", days));
-    }
-    if hours > 0 {
-        parts.push(format!("{} hours", hours));
-    }
-    if minutes > 0 {
-        parts.push(format!("{} mins", minutes));
-    }
-    if seconds > 0 {
-        parts.push(format!("{} secs", seconds));
-    }
-
-    parts.into_iter().take(2).collect::<Vec<_>>().join(" ")
 }
 
 #[test]
 fn test_format_eta() {
-    assert_eq!(format_eta(0), "0 secs");
-    assert_eq!(format_eta(999), "0 secs");
+    assert_eq!(format_eta(0), "any time now");
+    assert_eq!(format_eta(999), "any time now");
     assert_eq!(format_eta(1000), "1 secs");
     assert_eq!(format_eta(60_000), "1 mins");
     assert_eq!(format_eta(60_999), "1 mins");
     assert_eq!(format_eta(120_000), "2 mins");
     assert_eq!(format_eta(3_600_000), "1 hours");
     assert_eq!(format_eta(3_600_999), "1 hours");
-    assert_eq!(format_eta(3_661_000), "1 hours 1 mins");
+    assert_eq!(format_eta(3_661_000), "1 hours");
     assert_eq!(format_eta(86_400_000), "1 days");
-    assert_eq!(format_eta(86_460_000), "1 days 1 mins");
+    assert_eq!(format_eta(86_460_000), "1 days");
     assert_eq!(format_eta(604_800_000), "1 weeks");
-    assert_eq!(format_eta(604_860_000), "1 weeks 1 mins");
-    assert_eq!(format_eta(1_000_000), "16 mins 40 secs");
-    assert_eq!(format_eta(10_000_000), "2 hours 46 mins");
-    assert_eq!(format_eta(864_000_000), "1 weeks 3 days");
+    assert_eq!(format_eta(604_860_000), "1 weeks");
+    assert_eq!(format_eta(1_000_000), "16 mins");
+    assert_eq!(format_eta(10_000_000), "2 hours");
+    assert_eq!(format_eta(864_000_000), "1 weeks");
 }

--- a/src/frontend/utils.rs
+++ b/src/frontend/utils.rs
@@ -20,19 +20,19 @@ pub(crate) fn format_eta(eta_secs: u64) -> String {
 #[test]
 fn test_format_eta() {
     assert_eq!(format_eta(0), "any time now");
-    assert_eq!(format_eta(999), "any time now");
-    assert_eq!(format_eta(1000), "1 secs");
-    assert_eq!(format_eta(60_000), "1 mins");
-    assert_eq!(format_eta(60_999), "1 mins");
-    assert_eq!(format_eta(120_000), "2 mins");
-    assert_eq!(format_eta(3_600_000), "1 hours");
-    assert_eq!(format_eta(3_600_999), "1 hours");
-    assert_eq!(format_eta(3_661_000), "1 hours");
-    assert_eq!(format_eta(86_400_000), "1 days");
-    assert_eq!(format_eta(86_460_000), "1 days");
-    assert_eq!(format_eta(604_800_000), "1 weeks");
-    assert_eq!(format_eta(604_860_000), "1 weeks");
-    assert_eq!(format_eta(1_000_000), "16 mins");
-    assert_eq!(format_eta(10_000_000), "2 hours");
-    assert_eq!(format_eta(864_000_000), "1 weeks");
+    assert_eq!(format_eta(999), "16 mins");
+    assert_eq!(format_eta(1), "1 secs");
+    assert_eq!(format_eta(60), "1 mins");
+    assert_eq!(format_eta(61), "1 mins");
+    assert_eq!(format_eta(120), "2 mins");
+    assert_eq!(format_eta(3_600), "1 hours");
+    assert_eq!(format_eta(3_699), "1 hours");
+    assert_eq!(format_eta(3_661), "1 hours");
+    assert_eq!(format_eta(86_400), "1 days");
+    assert_eq!(format_eta(86_460), "1 days");
+    assert_eq!(format_eta(604_800), "1 weeks");
+    assert_eq!(format_eta(604_860), "1 weeks");
+    assert_eq!(format_eta(1_000), "16 mins");
+    assert_eq!(format_eta(10_000_000), "16 weeks");
+    assert_eq!(format_eta(864_000), "1 weeks");
 }

--- a/src/frontend/utils.rs
+++ b/src/frontend/utils.rs
@@ -1,0 +1,58 @@
+const WEEK: u64 = 604800000;
+const DAY: u64 = 86400000;
+const HOUR: u64 = 3600000;
+const MINUTE: u64 = 60000;
+const SECOND: u64 = 1000;
+
+/// Format ETA from milliseconds to a human-readable string with up to two time units
+pub(crate) fn format_eta(eta_millis: u64) -> String {
+    if eta_millis == 0 || eta_millis < SECOND {
+        return "0 secs".to_string();
+    }
+
+    let weeks = eta_millis / WEEK;
+    let days = (eta_millis % WEEK) / DAY;
+    let hours = (eta_millis % DAY) / HOUR;
+    let minutes = (eta_millis % HOUR) / MINUTE;
+    let seconds = (eta_millis % MINUTE) / SECOND;
+
+    let mut parts = Vec::new();
+
+    if weeks > 0 {
+        parts.push(format!("{} weeks", weeks));
+    }
+    if days > 0 {
+        parts.push(format!("{} days", days));
+    }
+    if hours > 0 {
+        parts.push(format!("{} hours", hours));
+    }
+    if minutes > 0 {
+        parts.push(format!("{} mins", minutes));
+    }
+    if seconds > 0 {
+        parts.push(format!("{} secs", seconds));
+    }
+
+    parts.into_iter().take(2).collect::<Vec<_>>().join(" ")
+}
+
+#[test]
+fn test_format_eta() {
+    assert_eq!(format_eta(0), "0 secs");
+    assert_eq!(format_eta(999), "0 secs");
+    assert_eq!(format_eta(1000), "1 secs");
+    assert_eq!(format_eta(60_000), "1 mins");
+    assert_eq!(format_eta(60_999), "1 mins");
+    assert_eq!(format_eta(120_000), "2 mins");
+    assert_eq!(format_eta(3_600_000), "1 hours");
+    assert_eq!(format_eta(3_600_999), "1 hours");
+    assert_eq!(format_eta(3_661_000), "1 hours 1 mins");
+    assert_eq!(format_eta(86_400_000), "1 days");
+    assert_eq!(format_eta(86_460_000), "1 days 1 mins");
+    assert_eq!(format_eta(604_800_000), "1 weeks");
+    assert_eq!(format_eta(604_860_000), "1 weeks 1 mins");
+    assert_eq!(format_eta(1_000_000), "16 mins 40 secs");
+    assert_eq!(format_eta(10_000_000), "2 hours 46 mins");
+    assert_eq!(format_eta(864_000_000), "1 weeks 3 days");
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -737,6 +737,10 @@ impl App {
             BackendNotification::IrrecoverableError { error } => {
                 self.current_view = View::Error(error);
             }
+            BackendNotification::AllocatedDiskSpace(disk_space) => {
+                self.running_view
+                    .emit(RunningInput::AllocatedDiskSpace(disk_space));
+            }
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -710,6 +710,7 @@ impl App {
                 reward_address_balance,
                 initial_farm_states,
                 chain_info,
+                chain_constants,
             } => {
                 self.current_raw_config.replace(raw_config.clone());
                 self.current_view = View::Running;
@@ -719,6 +720,7 @@ impl App {
                     initial_farm_states,
                     raw_config,
                     chain_info,
+                    chain_constants,
                 });
             }
             BackendNotification::Node(node_notification) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -718,7 +718,7 @@ impl App {
                     best_block_number,
                     reward_address_balance,
                     initial_farm_states,
-                    raw_config: Box::new(raw_config),
+                    raw_config,
                     chain_info,
                     chain_constants,
                 });

--- a/src/main.rs
+++ b/src/main.rs
@@ -718,7 +718,7 @@ impl App {
                     best_block_number,
                     reward_address_balance,
                     initial_farm_states,
-                    raw_config,
+                    raw_config: Box::new(raw_config),
                     chain_info,
                     chain_constants,
                 });


### PR DESCRIPTION
## Background

The [issue](https://github.com/subspace/space-acres/issues/86) titled "Predict when the next reward will be farmed" discusses the potential to provide users (farmers) with predictions on when they can expect to receive rewards based on on-chain data regarding space pledged and the last farming reward payment timestamp. This prediction could then be displayed to the user as having a high/low probability of receiving a reward with descriptions like "today", "in about an hour", or "any time now".

## Description

This PR adds:
- circular progress bar widget to show the next reward ETA (in sec, min, hr, day, week).
- function to calculate total space pledged based on retrieved fields - `slot_probability` (from frontend), `current_solution_range`, `max_pieces_in_sector` (from backend).
- `calculate_expected_reward_duration_from_now` function to calculate the ETA for next reward payment.

> A test code snippet is present in the [code](https://github.com/subspace/space-acres/blob/3ae68cbb487054ea73735d6f6d4bc7a9118e3bd6/src/frontend/running.rs#L447-L452) (commented) to see how it works. Just uncomment to test it by toggling FarmDetails button.