### PR TITLE
Update Subspace to the gemini-3h-2024-jul-16 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2168,7 +2168,7 @@ checksum = "7059fff8937831a9ae6f0fe4d658ffabf58f2ca96aa9dec1c889f936f705f216"
 [[package]]
 name = "cross-domain-message-gossip"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=95b4183fe1d5de7ac96a6961e42ac7053e3360f4#95b4183fe1d5de7ac96a6961e42ac7053e3360f4"
+source = "git+https://github.com/subspace/subspace?rev=8a1e2ed892a0f5ef026b1709341925c0ffd4c595#8a1e2ed892a0f5ef026b1709341925c0ffd4c595"
 dependencies = [
  "domain-block-preprocessor",
  "fp-account",
@@ -2646,7 +2646,7 @@ dependencies = [
 [[package]]
 name = "domain-block-preprocessor"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=95b4183fe1d5de7ac96a6961e42ac7053e3360f4#95b4183fe1d5de7ac96a6961e42ac7053e3360f4"
+source = "git+https://github.com/subspace/subspace?rev=8a1e2ed892a0f5ef026b1709341925c0ffd4c595#8a1e2ed892a0f5ef026b1709341925c0ffd4c595"
 dependencies = [
  "async-trait",
  "domain-runtime-primitives",
@@ -2664,8 +2664,10 @@ dependencies = [
  "sp-externalities",
  "sp-inherents",
  "sp-messenger",
+ "sp-mmr-primitives",
  "sp-runtime",
  "sp-state-machine",
+ "sp-subspace-mmr",
  "sp-timestamp",
  "sp-version",
  "sp-weights",
@@ -2677,7 +2679,7 @@ dependencies = [
 [[package]]
 name = "domain-runtime-primitives"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=95b4183fe1d5de7ac96a6961e42ac7053e3360f4#95b4183fe1d5de7ac96a6961e42ac7053e3360f4"
+source = "git+https://github.com/subspace/subspace?rev=8a1e2ed892a0f5ef026b1709341925c0ffd4c595#8a1e2ed892a0f5ef026b1709341925c0ffd4c595"
 dependencies = [
  "fixed-hash",
  "fp-account",
@@ -9243,7 +9245,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-subspace"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=95b4183fe1d5de7ac96a6961e42ac7053e3360f4#95b4183fe1d5de7ac96a6961e42ac7053e3360f4"
+source = "git+https://github.com/subspace/subspace?rev=8a1e2ed892a0f5ef026b1709341925c0ffd4c595#8a1e2ed892a0f5ef026b1709341925c0ffd4c595"
 dependencies = [
  "async-trait",
  "futures",
@@ -9283,7 +9285,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-subspace-rpc"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=95b4183fe1d5de7ac96a6961e42ac7053e3360f4#95b4183fe1d5de7ac96a6961e42ac7053e3360f4"
+source = "git+https://github.com/subspace/subspace?rev=8a1e2ed892a0f5ef026b1709341925c0ffd4c595#8a1e2ed892a0f5ef026b1709341925c0ffd4c595"
 dependencies = [
  "async-oneshot",
  "futures",
@@ -9316,7 +9318,7 @@ dependencies = [
 [[package]]
 name = "sc-domains"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=95b4183fe1d5de7ac96a6961e42ac7053e3360f4#95b4183fe1d5de7ac96a6961e42ac7053e3360f4"
+source = "git+https://github.com/subspace/subspace?rev=8a1e2ed892a0f5ef026b1709341925c0ffd4c595#8a1e2ed892a0f5ef026b1709341925c0ffd4c595"
 dependencies = [
  "sc-client-api",
  "sc-executor",
@@ -9679,7 +9681,7 @@ dependencies = [
 [[package]]
 name = "sc-proof-of-time"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=95b4183fe1d5de7ac96a6961e42ac7053e3360f4#95b4183fe1d5de7ac96a6961e42ac7053e3360f4"
+source = "git+https://github.com/subspace/subspace?rev=8a1e2ed892a0f5ef026b1709341925c0ffd4c595#8a1e2ed892a0f5ef026b1709341925c0ffd4c595"
 dependencies = [
  "atomic",
  "core_affinity",
@@ -9911,7 +9913,7 @@ dependencies = [
 [[package]]
 name = "sc-subspace-block-relay"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=95b4183fe1d5de7ac96a6961e42ac7053e3360f4#95b4183fe1d5de7ac96a6961e42ac7053e3360f4"
+source = "git+https://github.com/subspace/subspace?rev=8a1e2ed892a0f5ef026b1709341925c0ffd4c595#8a1e2ed892a0f5ef026b1709341925c0ffd4c595"
 dependencies = [
  "async-channel 1.9.0",
  "async-trait",
@@ -9936,7 +9938,7 @@ dependencies = [
 [[package]]
 name = "sc-subspace-chain-specs"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=95b4183fe1d5de7ac96a6961e42ac7053e3360f4#95b4183fe1d5de7ac96a6961e42ac7053e3360f4"
+source = "git+https://github.com/subspace/subspace?rev=8a1e2ed892a0f5ef026b1709341925c0ffd4c595#8a1e2ed892a0f5ef026b1709341925c0ffd4c595"
 
 [[package]]
 name = "sc-sysinfo"
@@ -10681,7 +10683,7 @@ dependencies = [
 [[package]]
 name = "sp-auto-id"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=95b4183fe1d5de7ac96a6961e42ac7053e3360f4#95b4183fe1d5de7ac96a6961e42ac7053e3360f4"
+source = "git+https://github.com/subspace/subspace?rev=8a1e2ed892a0f5ef026b1709341925c0ffd4c595#8a1e2ed892a0f5ef026b1709341925c0ffd4c595"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -10705,7 +10707,7 @@ dependencies = [
 [[package]]
 name = "sp-block-fees"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=95b4183fe1d5de7ac96a6961e42ac7053e3360f4#95b4183fe1d5de7ac96a6961e42ac7053e3360f4"
+source = "git+https://github.com/subspace/subspace?rev=8a1e2ed892a0f5ef026b1709341925c0ffd4c595#8a1e2ed892a0f5ef026b1709341925c0ffd4c595"
 dependencies = [
  "async-trait",
  "domain-runtime-primitives",
@@ -10799,7 +10801,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-subspace"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=95b4183fe1d5de7ac96a6961e42ac7053e3360f4#95b4183fe1d5de7ac96a6961e42ac7053e3360f4"
+source = "git+https://github.com/subspace/subspace?rev=8a1e2ed892a0f5ef026b1709341925c0ffd4c595#8a1e2ed892a0f5ef026b1709341925c0ffd4c595"
 dependencies = [
  "async-trait",
  "log",
@@ -10935,7 +10937,7 @@ dependencies = [
 [[package]]
 name = "sp-domain-digests"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=95b4183fe1d5de7ac96a6961e42ac7053e3360f4#95b4183fe1d5de7ac96a6961e42ac7053e3360f4"
+source = "git+https://github.com/subspace/subspace?rev=8a1e2ed892a0f5ef026b1709341925c0ffd4c595#8a1e2ed892a0f5ef026b1709341925c0ffd4c595"
 dependencies = [
  "parity-scale-codec",
  "sp-runtime",
@@ -10944,7 +10946,7 @@ dependencies = [
 [[package]]
 name = "sp-domain-sudo"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=95b4183fe1d5de7ac96a6961e42ac7053e3360f4#95b4183fe1d5de7ac96a6961e42ac7053e3360f4"
+source = "git+https://github.com/subspace/subspace?rev=8a1e2ed892a0f5ef026b1709341925c0ffd4c595#8a1e2ed892a0f5ef026b1709341925c0ffd4c595"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -10955,7 +10957,7 @@ dependencies = [
 [[package]]
 name = "sp-domains"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=95b4183fe1d5de7ac96a6961e42ac7053e3360f4#95b4183fe1d5de7ac96a6961e42ac7053e3360f4"
+source = "git+https://github.com/subspace/subspace?rev=8a1e2ed892a0f5ef026b1709341925c0ffd4c595#8a1e2ed892a0f5ef026b1709341925c0ffd4c595"
 dependencies = [
  "blake2 0.10.6",
  "domain-runtime-primitives",
@@ -10987,7 +10989,7 @@ dependencies = [
 [[package]]
 name = "sp-domains-fraud-proof"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=95b4183fe1d5de7ac96a6961e42ac7053e3360f4#95b4183fe1d5de7ac96a6961e42ac7053e3360f4"
+source = "git+https://github.com/subspace/subspace?rev=8a1e2ed892a0f5ef026b1709341925c0ffd4c595#8a1e2ed892a0f5ef026b1709341925c0ffd4c595"
 dependencies = [
  "domain-block-preprocessor",
  "domain-runtime-primitives",
@@ -11022,7 +11024,7 @@ dependencies = [
 [[package]]
 name = "sp-executive"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=95b4183fe1d5de7ac96a6961e42ac7053e3360f4#95b4183fe1d5de7ac96a6961e42ac7053e3360f4"
+source = "git+https://github.com/subspace/subspace?rev=8a1e2ed892a0f5ef026b1709341925c0ffd4c595#8a1e2ed892a0f5ef026b1709341925c0ffd4c595"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -11113,7 +11115,7 @@ dependencies = [
 [[package]]
 name = "sp-messenger"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=95b4183fe1d5de7ac96a6961e42ac7053e3360f4#95b4183fe1d5de7ac96a6961e42ac7053e3360f4"
+source = "git+https://github.com/subspace/subspace?rev=8a1e2ed892a0f5ef026b1709341925c0ffd4c595#8a1e2ed892a0f5ef026b1709341925c0ffd4c595"
 dependencies = [
  "async-trait",
  "frame-support",
@@ -11135,7 +11137,7 @@ dependencies = [
 [[package]]
 name = "sp-messenger-host-functions"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=95b4183fe1d5de7ac96a6961e42ac7053e3360f4#95b4183fe1d5de7ac96a6961e42ac7053e3360f4"
+source = "git+https://github.com/subspace/subspace?rev=8a1e2ed892a0f5ef026b1709341925c0ffd4c595#8a1e2ed892a0f5ef026b1709341925c0ffd4c595"
 dependencies = [
  "domain-block-preprocessor",
  "parity-scale-codec",
@@ -11192,7 +11194,7 @@ dependencies = [
 [[package]]
 name = "sp-objects"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=95b4183fe1d5de7ac96a6961e42ac7053e3360f4#95b4183fe1d5de7ac96a6961e42ac7053e3360f4"
+source = "git+https://github.com/subspace/subspace?rev=8a1e2ed892a0f5ef026b1709341925c0ffd4c595#8a1e2ed892a0f5ef026b1709341925c0ffd4c595"
 dependencies = [
  "sp-api",
  "subspace-core-primitives",
@@ -11377,7 +11379,7 @@ dependencies = [
 [[package]]
 name = "sp-subspace-mmr"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=95b4183fe1d5de7ac96a6961e42ac7053e3360f4#95b4183fe1d5de7ac96a6961e42ac7053e3360f4"
+source = "git+https://github.com/subspace/subspace?rev=8a1e2ed892a0f5ef026b1709341925c0ffd4c595#8a1e2ed892a0f5ef026b1709341925c0ffd4c595"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -11516,7 +11518,7 @@ dependencies = [
 
 [[package]]
 name = "space-acres"
-version = "0.1.26"
+version = "0.1.27"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -11722,7 +11724,7 @@ dependencies = [
 [[package]]
 name = "subspace-archiving"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=95b4183fe1d5de7ac96a6961e42ac7053e3360f4#95b4183fe1d5de7ac96a6961e42ac7053e3360f4"
+source = "git+https://github.com/subspace/subspace?rev=8a1e2ed892a0f5ef026b1709341925c0ffd4c595#8a1e2ed892a0f5ef026b1709341925c0ffd4c595"
 dependencies = [
  "parity-scale-codec",
  "rayon",
@@ -11735,7 +11737,7 @@ dependencies = [
 [[package]]
 name = "subspace-core-primitives"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=95b4183fe1d5de7ac96a6961e42ac7053e3360f4#95b4183fe1d5de7ac96a6961e42ac7053e3360f4"
+source = "git+https://github.com/subspace/subspace?rev=8a1e2ed892a0f5ef026b1709341925c0ffd4c595#8a1e2ed892a0f5ef026b1709341925c0ffd4c595"
 dependencies = [
  "blake3",
  "bytes",
@@ -11759,7 +11761,7 @@ dependencies = [
 [[package]]
 name = "subspace-erasure-coding"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=95b4183fe1d5de7ac96a6961e42ac7053e3360f4#95b4183fe1d5de7ac96a6961e42ac7053e3360f4"
+source = "git+https://github.com/subspace/subspace?rev=8a1e2ed892a0f5ef026b1709341925c0ffd4c595#8a1e2ed892a0f5ef026b1709341925c0ffd4c595"
 dependencies = [
  "kzg",
  "rust-kzg-blst",
@@ -11769,7 +11771,7 @@ dependencies = [
 [[package]]
 name = "subspace-fake-runtime-api"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=95b4183fe1d5de7ac96a6961e42ac7053e3360f4#95b4183fe1d5de7ac96a6961e42ac7053e3360f4"
+source = "git+https://github.com/subspace/subspace?rev=8a1e2ed892a0f5ef026b1709341925c0ffd4c595#8a1e2ed892a0f5ef026b1709341925c0ffd4c595"
 dependencies = [
  "domain-runtime-primitives",
  "frame-support",
@@ -11791,6 +11793,7 @@ dependencies = [
  "sp-offchain",
  "sp-runtime",
  "sp-session",
+ "sp-subspace-mmr",
  "sp-transaction-pool",
  "sp-version",
  "subspace-core-primitives",
@@ -11800,7 +11803,7 @@ dependencies = [
 [[package]]
 name = "subspace-farmer"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=95b4183fe1d5de7ac96a6961e42ac7053e3360f4#95b4183fe1d5de7ac96a6961e42ac7053e3360f4"
+source = "git+https://github.com/subspace/subspace?rev=8a1e2ed892a0f5ef026b1709341925c0ffd4c595#8a1e2ed892a0f5ef026b1709341925c0ffd4c595"
 dependencies = [
  "anyhow",
  "async-lock",
@@ -11861,7 +11864,7 @@ dependencies = [
 [[package]]
 name = "subspace-farmer-components"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=95b4183fe1d5de7ac96a6961e42ac7053e3360f4#95b4183fe1d5de7ac96a6961e42ac7053e3360f4"
+source = "git+https://github.com/subspace/subspace?rev=8a1e2ed892a0f5ef026b1709341925c0ffd4c595#8a1e2ed892a0f5ef026b1709341925c0ffd4c595"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -11892,7 +11895,7 @@ dependencies = [
 [[package]]
 name = "subspace-metrics"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=95b4183fe1d5de7ac96a6961e42ac7053e3360f4#95b4183fe1d5de7ac96a6961e42ac7053e3360f4"
+source = "git+https://github.com/subspace/subspace?rev=8a1e2ed892a0f5ef026b1709341925c0ffd4c595#8a1e2ed892a0f5ef026b1709341925c0ffd4c595"
 dependencies = [
  "actix-web",
  "prometheus",
@@ -11903,7 +11906,7 @@ dependencies = [
 [[package]]
 name = "subspace-networking"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=95b4183fe1d5de7ac96a6961e42ac7053e3360f4#95b4183fe1d5de7ac96a6961e42ac7053e3360f4"
+source = "git+https://github.com/subspace/subspace?rev=8a1e2ed892a0f5ef026b1709341925c0ffd4c595#8a1e2ed892a0f5ef026b1709341925c0ffd4c595"
 dependencies = [
  "async-mutex",
  "async-trait",
@@ -11941,7 +11944,7 @@ dependencies = [
 [[package]]
 name = "subspace-proof-of-space"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=95b4183fe1d5de7ac96a6961e42ac7053e3360f4#95b4183fe1d5de7ac96a6961e42ac7053e3360f4"
+source = "git+https://github.com/subspace/subspace?rev=8a1e2ed892a0f5ef026b1709341925c0ffd4c595#8a1e2ed892a0f5ef026b1709341925c0ffd4c595"
 dependencies = [
  "chacha20",
  "derive_more",
@@ -11956,7 +11959,7 @@ dependencies = [
 [[package]]
 name = "subspace-proof-of-time"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=95b4183fe1d5de7ac96a6961e42ac7053e3360f4#95b4183fe1d5de7ac96a6961e42ac7053e3360f4"
+source = "git+https://github.com/subspace/subspace?rev=8a1e2ed892a0f5ef026b1709341925c0ffd4c595#8a1e2ed892a0f5ef026b1709341925c0ffd4c595"
 dependencies = [
  "aes",
  "subspace-core-primitives",
@@ -11966,7 +11969,7 @@ dependencies = [
 [[package]]
 name = "subspace-rpc-primitives"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=95b4183fe1d5de7ac96a6961e42ac7053e3360f4#95b4183fe1d5de7ac96a6961e42ac7053e3360f4"
+source = "git+https://github.com/subspace/subspace?rev=8a1e2ed892a0f5ef026b1709341925c0ffd4c595#8a1e2ed892a0f5ef026b1709341925c0ffd4c595"
 dependencies = [
  "hex",
  "parity-scale-codec",
@@ -11979,7 +11982,7 @@ dependencies = [
 [[package]]
 name = "subspace-runtime-primitives"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=95b4183fe1d5de7ac96a6961e42ac7053e3360f4#95b4183fe1d5de7ac96a6961e42ac7053e3360f4"
+source = "git+https://github.com/subspace/subspace?rev=8a1e2ed892a0f5ef026b1709341925c0ffd4c595#8a1e2ed892a0f5ef026b1709341925c0ffd4c595"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -11994,7 +11997,7 @@ dependencies = [
 [[package]]
 name = "subspace-service"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=95b4183fe1d5de7ac96a6961e42ac7053e3360f4#95b4183fe1d5de7ac96a6961e42ac7053e3360f4"
+source = "git+https://github.com/subspace/subspace?rev=8a1e2ed892a0f5ef026b1709341925c0ffd4c595#8a1e2ed892a0f5ef026b1709341925c0ffd4c595"
 dependencies = [
  "async-trait",
  "cross-domain-message-gossip",
@@ -12072,7 +12075,7 @@ dependencies = [
 [[package]]
 name = "subspace-verification"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=95b4183fe1d5de7ac96a6961e42ac7053e3360f4#95b4183fe1d5de7ac96a6961e42ac7053e3360f4"
+source = "git+https://github.com/subspace/subspace?rev=8a1e2ed892a0f5ef026b1709341925c0ffd4c595#8a1e2ed892a0f5ef026b1709341925c0ffd4c595"
 dependencies = [
  "parity-scale-codec",
  "schnorrkel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "space-acres"
 description = "Space Acres is an opinionated GUI application for farming on Subspace Network"
 license = "0BSD"
-version = "0.1.26"
+version = "0.1.27"
 authors = ["Nazar Mokrynskyi <nazar@mokrynskyi.com>"]
 repository = "https://github.com/subspace/space-acres"
 edition = "2021"
@@ -70,14 +70,14 @@ reqwest = { version = "0.12.4", default-features = false, features = ["json", "r
 sc-client-api = { git = "https://github.com/subspace/polkadot-sdk", rev = "0cbfcb0232bbf71ac5b14cc8c99bf043cec420ef", default-features = false }
 sc-client-db = { git = "https://github.com/subspace/polkadot-sdk", rev = "0cbfcb0232bbf71ac5b14cc8c99bf043cec420ef", default-features = false }
 sc-consensus-slots = { git = "https://github.com/subspace/polkadot-sdk", rev = "0cbfcb0232bbf71ac5b14cc8c99bf043cec420ef", default-features = false }
-sc-consensus-subspace = { git = "https://github.com/subspace/subspace", rev = "95b4183fe1d5de7ac96a6961e42ac7053e3360f4" }
+sc-consensus-subspace = { git = "https://github.com/subspace/subspace", rev = "8a1e2ed892a0f5ef026b1709341925c0ffd4c595" }
 sc-informant = { git = "https://github.com/subspace/polkadot-sdk", rev = "0cbfcb0232bbf71ac5b14cc8c99bf043cec420ef", default-features = false }
 sc-network = { git = "https://github.com/subspace/polkadot-sdk", rev = "0cbfcb0232bbf71ac5b14cc8c99bf043cec420ef", default-features = false }
 sc-network-types = { git = "https://github.com/subspace/polkadot-sdk", rev = "0cbfcb0232bbf71ac5b14cc8c99bf043cec420ef", default-features = false }
 sc-rpc = { git = "https://github.com/subspace/polkadot-sdk", rev = "0cbfcb0232bbf71ac5b14cc8c99bf043cec420ef", default-features = false }
 sc-service = { git = "https://github.com/subspace/polkadot-sdk", rev = "0cbfcb0232bbf71ac5b14cc8c99bf043cec420ef", default-features = false }
 sc-storage-monitor = { git = "https://github.com/subspace/polkadot-sdk", rev = "0cbfcb0232bbf71ac5b14cc8c99bf043cec420ef", default-features = false }
-sc-subspace-chain-specs = { git = "https://github.com/subspace/subspace", rev = "95b4183fe1d5de7ac96a6961e42ac7053e3360f4" }
+sc-subspace-chain-specs = { git = "https://github.com/subspace/subspace", rev = "8a1e2ed892a0f5ef026b1709341925c0ffd4c595" }
 sc-utils = { git = "https://github.com/subspace/polkadot-sdk", rev = "0cbfcb0232bbf71ac5b14cc8c99bf043cec420ef", default-features = false }
 schnellru = "0.2.3"
 semver = "1.0.23"
@@ -87,22 +87,22 @@ simple_moving_average = "1.0.2"
 sp-api = { git = "https://github.com/subspace/polkadot-sdk", rev = "0cbfcb0232bbf71ac5b14cc8c99bf043cec420ef", default-features = false }
 sp-blockchain = { git = "https://github.com/subspace/polkadot-sdk", rev = "0cbfcb0232bbf71ac5b14cc8c99bf043cec420ef", default-features = false }
 sp-consensus = { git = "https://github.com/subspace/polkadot-sdk", rev = "0cbfcb0232bbf71ac5b14cc8c99bf043cec420ef", default-features = false }
-sp-consensus-subspace = { git = "https://github.com/subspace/subspace", rev = "95b4183fe1d5de7ac96a6961e42ac7053e3360f4" }
+sp-consensus-subspace = { git = "https://github.com/subspace/subspace", rev = "8a1e2ed892a0f5ef026b1709341925c0ffd4c595" }
 sp-core = { git = "https://github.com/subspace/polkadot-sdk", rev = "0cbfcb0232bbf71ac5b14cc8c99bf043cec420ef", default-features = false }
-sp-domains-fraud-proof = { git = "https://github.com/subspace/subspace", rev = "95b4183fe1d5de7ac96a6961e42ac7053e3360f4" }
-sp-objects = { git = "https://github.com/subspace/subspace", rev = "95b4183fe1d5de7ac96a6961e42ac7053e3360f4" }
+sp-domains-fraud-proof = { git = "https://github.com/subspace/subspace", rev = "8a1e2ed892a0f5ef026b1709341925c0ffd4c595" }
+sp-objects = { git = "https://github.com/subspace/subspace", rev = "8a1e2ed892a0f5ef026b1709341925c0ffd4c595" }
 sp-runtime = { git = "https://github.com/subspace/polkadot-sdk", rev = "0cbfcb0232bbf71ac5b14cc8c99bf043cec420ef", default-features = false }
-subspace-archiving = { git = "https://github.com/subspace/subspace", rev = "95b4183fe1d5de7ac96a6961e42ac7053e3360f4" }
-subspace-core-primitives = { git = "https://github.com/subspace/subspace", rev = "95b4183fe1d5de7ac96a6961e42ac7053e3360f4" }
-subspace-erasure-coding = { git = "https://github.com/subspace/subspace", rev = "95b4183fe1d5de7ac96a6961e42ac7053e3360f4" }
-subspace-fake-runtime-api = { git = "https://github.com/subspace/subspace", rev = "95b4183fe1d5de7ac96a6961e42ac7053e3360f4" }
-subspace-farmer = { git = "https://github.com/subspace/subspace", rev = "95b4183fe1d5de7ac96a6961e42ac7053e3360f4", default-features = false }
-subspace-farmer-components = { git = "https://github.com/subspace/subspace", rev = "95b4183fe1d5de7ac96a6961e42ac7053e3360f4" }
-subspace-networking = { git = "https://github.com/subspace/subspace", rev = "95b4183fe1d5de7ac96a6961e42ac7053e3360f4" }
-subspace-proof-of-space = { git = "https://github.com/subspace/subspace", rev = "95b4183fe1d5de7ac96a6961e42ac7053e3360f4" }
-subspace-rpc-primitives = { git = "https://github.com/subspace/subspace", rev = "95b4183fe1d5de7ac96a6961e42ac7053e3360f4" }
-subspace-runtime-primitives = { git = "https://github.com/subspace/subspace", rev = "95b4183fe1d5de7ac96a6961e42ac7053e3360f4" }
-subspace-service = { git = "https://github.com/subspace/subspace", rev = "95b4183fe1d5de7ac96a6961e42ac7053e3360f4" }
+subspace-archiving = { git = "https://github.com/subspace/subspace", rev = "8a1e2ed892a0f5ef026b1709341925c0ffd4c595" }
+subspace-core-primitives = { git = "https://github.com/subspace/subspace", rev = "8a1e2ed892a0f5ef026b1709341925c0ffd4c595" }
+subspace-erasure-coding = { git = "https://github.com/subspace/subspace", rev = "8a1e2ed892a0f5ef026b1709341925c0ffd4c595" }
+subspace-fake-runtime-api = { git = "https://github.com/subspace/subspace", rev = "8a1e2ed892a0f5ef026b1709341925c0ffd4c595" }
+subspace-farmer = { git = "https://github.com/subspace/subspace", rev = "8a1e2ed892a0f5ef026b1709341925c0ffd4c595", default-features = false }
+subspace-farmer-components = { git = "https://github.com/subspace/subspace", rev = "8a1e2ed892a0f5ef026b1709341925c0ffd4c595" }
+subspace-networking = { git = "https://github.com/subspace/subspace", rev = "8a1e2ed892a0f5ef026b1709341925c0ffd4c595" }
+subspace-proof-of-space = { git = "https://github.com/subspace/subspace", rev = "8a1e2ed892a0f5ef026b1709341925c0ffd4c595" }
+subspace-rpc-primitives = { git = "https://github.com/subspace/subspace", rev = "8a1e2ed892a0f5ef026b1709341925c0ffd4c595" }
+subspace-runtime-primitives = { git = "https://github.com/subspace/subspace", rev = "8a1e2ed892a0f5ef026b1709341925c0ffd4c595" }
+subspace-service = { git = "https://github.com/subspace/subspace", rev = "8a1e2ed892a0f5ef026b1709341925c0ffd4c595" }
 supports-color = "3.0.0"
 thiserror = "1.0.61"
 thread-priority = "1.1.0"

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -857,6 +857,7 @@ async fn create_networking_stack(
         maybe_node_client.clone(),
         subspace_networking::libp2p::identity::PublicKey::from(network_keypair.public())
             .to_peer_id(),
+        None,
     );
 
     let (node, node_runner) = create_network(

--- a/src/backend/farmer.rs
+++ b/src/backend/farmer.rs
@@ -303,6 +303,7 @@ where
         Arc::clone(&global_mutex),
         kzg.clone(),
         erasure_coding.clone(),
+        None,
     ));
     let modern_cpu_plotter = Arc::new(CpuPlotter::<_, PosTable>::new(
         piece_getter.clone(),
@@ -312,6 +313,7 @@ where
         Arc::clone(&global_mutex),
         kzg.clone(),
         erasure_coding.clone(),
+        None,
     ));
 
     let (farms, plotting_delay_senders) = {
@@ -363,6 +365,7 @@ where
                             read_sector_record_chunks_mode: None,
                             faster_read_sector_record_chunks_mode_barrier,
                             faster_read_sector_record_chunks_mode_concurrency,
+                            registry: None,
                             create: true,
                         },
                         farm_index,


### PR DESCRIPTION
This PR upgrades the `subspace` dependency to the `gemini-3h-2024-jul-16` release and bump version to 0.1.27.